### PR TITLE
Proposed Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,91 @@
+---
+layout: default
+title: The Fawkes Code of Conduct
+---
+
+# The Fawkes Code of Conduct
+
+## Conduct
+
+**Contact**: [fawkes-mods@mozilla.com](mailto:fawkes-mods@mozilla.com)
+
+* We are committed to providing a friendly, safe and welcoming environment for
+  all, regardless of level of experience, gender, gender identity and
+  expression, sexual orientation, disability, personal appearance, body size,
+  race, ethnicity, age, religion, nationality, or other similar characteristic.
+* On chat-channels, please avoid using overtly sexual nicknames or other
+  nicknames that might detract from a friendly, safe and welcoming environment
+  for all.
+* Please be kind and courteous. There's no need to be mean or rude.
+* Respect that people have differences of opinion and that every design or
+  implementation choice carries a trade-off and numerous costs. There is seldom
+  a right answer.
+* Please keep unstructured critique to a minimum. If you have solid ideas you
+  want to experiment with, make a fork and see how it works.
+* We will exclude you from interaction if you insult, demean or harass anyone.
+  We interpret the term "harassment" as including the definition in the
+  [Citizen Code of Conduct](http://citizencodeofconduct.org); if you have any
+  lack of clarity about what might be included in that concept, please read
+  their definition. In particular, we don't tolerate behavior that excludes
+  people in socially marginalized groups.
+* Private harassment is also unacceptable. No matter who you are, if you feel
+  you have been or are being harassed or made uncomfortable by a community
+  member, please contact the
+  [Fawkes moderation team](mailto:fawkes-mods@mozilla.com) immediately. Whether
+  you're a regular contributor or a newcomer, we care about making this
+  community a safe place for you and we've got your back.
+* Likewise any spamming, trolling, flaming, baiting or other attention-stealing
+  behaviour is not welcome.
+
+
+## Moderation
+
+These are the policies for upholding our community's standards of conduct. If
+you feel that a thread needs moderation, please contact the
+[Fawkes moderation team](mailto:fawkes-mods@mozilla.com).
+
+1. Remarks that violate the Fawkes standards of conduct, including hateful,
+   hurtful, oppressive, or exclusionary remarks, are not allowed. (Cursing is
+   allowed, but never targeting another user, and never in a hateful manner.)
+2. Remarks that moderators find inappropriate, whether listed in the code of
+   conduct or not, are also not allowed.
+3. Moderators will first respond to such remarks with a warning.
+4. If the warning is unheeded, the user will be "kicked," i.e., kicked out of
+   the communication channel to cool off.
+5. If the user comes back and continues to make trouble, they will be banned,
+   i.e., indefinitely excluded.
+6. Moderators may choose at their discretion to un-ban the user if it was a
+   first offense and they offer the offended party a genuine apology.
+7. If a moderator bans someone and you think it was unjustified, please take it
+   up with that moderator, or with a different moderator, **in private**.
+   Complaints about bans in-channel are not allowed.
+8. Moderators are held to a higher standard than other community members. If a
+   moderator creates an inappropriate situation, they should expect less leeway
+   than others.
+
+In the Fawkes community we strive to go the extra step to look out for each
+other. Don't just aim to be technically unimpeachable, try to be your best self.
+In particular, avoid flirting with offensive or sensitive issues, particularly
+if they're off-topic; this all too often leads to unnecessary fights, hurt
+feelings, and damaged trust; worse, it can drive people away from the community
+entirely.
+
+And if someone takes issue with something you said or did, resist the urge to
+be defensive. Just stop doing what it was they complained about and apologize.
+Even if you feel you were misinterpreted or unfairly accused, chances are good
+there was something you could've communicated better — remember that it's your
+responsibility to make your fellow Fawkes community members comfortable.
+Everyone wants to get along and we are all here first and foremost because we
+want to talk about cool technology. You will find that people will be eager to
+assume good intent and forgive as long as you earn their trust.
+
+The enforcement policies listed above apply to all official Fawkes venues. For
+other projects adopting the Fawkes Code of Conduct, please contact the
+maintainers of those projects for enforcement. If you wish to use this code of
+conduct for your own project, consider explicitly mentioning your moderation
+policy or making a copy with your own moderation policy so as to avoid confusion.
+
+*Adapted from [The Rust Code of Conduct](https://www.rust-lang.org/conduct.html)
+which is based on the [Citizen Code of Conduct](http://citizencodeofconduct.org),
+the [Node.js Policy on Trolling](http://blog.izs.me/post/30036893703/policy-on-trolling)
+and the [Contributor Covenant v1.3.0](http://contributor-covenant.org/version/1/3/0/).*

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ The code uses examples from many different places, but the foundation was starte
 * http://pfraze.github.io/2015/09/08/building-electron-browser-pt1.html
 * https://github.com/pfraze/electron-browser
 
+
 ## Build
 
 ### Dependencies
@@ -34,6 +35,7 @@ The following tasks will most likely not need to be used externally, but as depe
 * `build` - Builds the client/renderer code.
 * `build-dev` - Builds the client/renderer code in development mode.
 
+
 ## Testing
 
 Currently runs eslint and ui tests with mocha.
@@ -44,15 +46,19 @@ npm test
 
 ## Landing code
 
+Please note that this project is released with a Contributor Code of Conduct.
+By participating in this project you agree to abide by its terms.
+
 Use squashed merge by preference.
 
 Make sure your commit message references the issue or bug number, if there is one, identifies the reviewers, and follows a readable style, with the long description including any additional information that's likely to help future spelunkers. For example:
 
 ```
     Issue #6 - Frobnicate the URL bazzer before flattening pilchard. r=mossop,rnewman
-    
+
     The frobnication method used is as described in Podder's Miscellany, page 15.
     Note that this pull request doesn't include tests, because we're bad people.
 ```
+
 
 ## License


### PR DESCRIPTION
Adapted from The Rust Code of Conduct [1](https://www.rust-lang.org/conduct.html) which is based on the Citizen Code
of Conduct [2](http://citizencodeofconduct.org), the Node.js Policy on Trolling [3](http://blog.izs.me/post/30036893703/policy-on-trolling) and the Contributor
Covenant [4](http://contributor-covenant.org/version/1/3/0/).

Signed-off-by: Joe Walker jwalker@mozilla.com
