### PR TITLE
Bump electron-prebuilt version

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "electron-download": "2.1.0",
     "electron-packager": "5.2.1",
-    "electron-prebuilt": "0.37.2",
+    "electron-prebuilt": "0.37.4",
     "enzyme": "2.2.0",
     "eslint": "2.4.0",
     "eslint-config-airbnb": "6.2.0",


### PR DESCRIPTION
Signed-off-by: Brian Grinstead <briangrinstead@gmail.com>

I was getting an error before updating:

    > electron-prebuilt@0.37.2 postinstall /fawkes/node_modules/electron-prebuilt
    > node install.js

    module.js:327
        throw err;
        ^

    Error: Cannot find module 'process-nextick-args'
