### PR TITLE
Start to reflect UX mockup - Move non-tab components out of tabbar, m…

### DIFF
--- a/static/browser.html
+++ b/static/browser.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="./css/browser.css">
     <link rel="stylesheet" href="./css/browser-tabs.css">
     <link rel="stylesheet" href="./css/browser-navbar.css">
+    <link rel="stylesheet" href="./css/browser-navbar-location.css">
     <link rel="stylesheet" href="./css/browser-page.css">
   </head>
   <body>

--- a/static/css/browser-navbar-location.css
+++ b/static/css/browser-navbar-location.css
@@ -1,0 +1,10 @@
+#browser-location-bar {
+  flex: 1;
+  display: flex;
+  margin: 0 5px;
+}
+
+#browser-location-bar input {
+  flex: 1;
+  display: flex;
+}

--- a/static/css/browser-navbar.css
+++ b/static/css/browser-navbar.css
@@ -8,9 +8,17 @@
   font-weight: 100;
   background: linear-gradient(to bottom, #eee, #ddd);
   border-bottom: 1px solid #aaa;
+
+  /* Makes electron app draggable */
+  -webkit-app-region: drag;
 }
 
 #browser-navbar a {
+  /* We should possibly make buttons in the navbar
+   * NOT drag the entire electron app window, but just leaving
+   * this here for now
+  -webkit-app-region: no-drag;
+  */
   text-decoration: none;
   color: #777;
   cursor: pointer;
@@ -41,29 +49,6 @@
   flex: 1;
   display: flex;
   margin: 0 5px;
-}
-
-#browser-navbar .input-group input {
-  flex: 1;
-  margin: 4px 0 3px;
-  padding: 0 5px;
-  font-size: 14px;
-  color: #808080;
-  outline: 0;
-  box-shadow: inset 0px 1px 2px rgba(0, 0, 0, 0.2);
-  background: #fff;
-  border: 1px solid #bbb;
-  border-top-left-radius: 3px;
-  border-bottom-left-radius: 3px;
-}
-
-#browser-navbar .input-group input:focus, 
-#browser-navbar .input-group input:active, 
-#browser-navbar .input-group input:hover {
-  outline: 0;
-  box-shadow: inset 0px 1px 2px rgba(0, 0, 0, 0.2);
-  background: #fff;
-  border: 1px solid #bbb;
 }
 
 #browser-navbar .input-group a {

--- a/static/css/browser-tabs.css
+++ b/static/css/browser-tabs.css
@@ -2,12 +2,10 @@
   display: flex;
   background: linear-gradient(to bottom, #ddd 90%, #bbb);
   font-size: 13px;
-  -webkit-app-region: drag;
   -webkit-touch-callout: none;
   -webkit-user-select: none;
 }
 #browser-tabs > div {
-  -webkit-app-region: no-drag;
   /*flex: 1;*/
   display: flex;
   min-width: 200px;

--- a/ui/browser/views/browser.jsx
+++ b/ui/browser/views/browser.jsx
@@ -9,6 +9,9 @@ import Page from './page/page.jsx';
 
 import { updateMenu } from '../actions/external';
 import { createTab, attachTab, setPageDetails } from '../actions/main-actions';
+
+import { platform } from '../../../build-config';
+
 require('../../shared/web-view');
 
 /**
@@ -21,11 +24,12 @@ class BrowserWindow extends Component {
 
   render() {
     const { pages, currentPageIndex, pageOrder } = this.props;
+    const platformClass = `platform-${platform}`;
 
     return (
-      <div id="browser-chrome">
-        <TabBar {...{ pages, pageOrder, currentPageIndex }} />
+      <div id="browser-chrome" className={"platform-" + platform} >
         <NavBar page={pages.get(currentPageIndex)} />
+        <TabBar {...{ pages, pageOrder, currentPageIndex }} />
         <div id="content-area">
           {pages.map((page, pageIndex) => (
             <Page key={'page-' + pageIndex}

--- a/ui/browser/views/navbar/location.jsx
+++ b/ui/browser/views/navbar/location.jsx
@@ -2,7 +2,8 @@
 import React, { PropTypes, Component } from 'react';
 import { connect } from 'react-redux';
 import { ipcRenderer } from 'electron';
-import { menuLocationContext } from '../../actions/external';
+import Btn from './btn.jsx';
+import { menuLocationContext, bookmark, unbookmark } from '../../actions/external';
 import { setLocation } from '../../actions/main-actions';
 import { fixURL, getCurrentWebView } from '../../browser-util';
 
@@ -38,13 +39,30 @@ class Location extends Component {
     const { page, dispatch } = this.props;
     const value = page.userTyped !== null ? page.userTyped : page.location;
 
+    const onBookmark = e => {
+      const webview = getCurrentWebView(e.target.ownerDocument);
+      const title = webview.getTitle();
+      const url = webview.getURL();
+      if (page.isBookmarked) {
+        unbookmark(url, dispatch);
+      } else {
+        bookmark(title, url, dispatch);
+      }
+    };
+
     return (
-      <input id="urlbar-input" type="text" ref="input"
-        value={value}
-        onChange={ev => dispatch(setLocation(ev.target.value))}
-        onClick={ev => ev.target.select()}
-        onContextMenu={ev => menuLocationContext(ev.target, dispatch)}
-        onKeyDown={this.handleKeyDown} />
+      <div id="browser-location-bar">
+        <input id="urlbar-input" type="text" ref="input"
+          value={value}
+          onChange={ev => dispatch(setLocation(ev.target.value))}
+          onClick={ev => ev.target.select()}
+          onContextMenu={ev => menuLocationContext(ev.target, dispatch)}
+          onKeyDown={this.handleKeyDown} />
+
+        <Btn title="Bookmark"
+          icon={page.isBookmarked ? 'star fa-lg' : 'star-o fa-lg'}
+          onClick={onBookmark} />
+      </div>
     );
   }
 }

--- a/ui/browser/views/navbar/navbar.jsx
+++ b/ui/browser/views/navbar/navbar.jsx
@@ -3,7 +3,7 @@ import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import Btn from './btn.jsx';
 import Location from './location.jsx';
-import { menuBrowser, bookmark, unbookmark } from '../../actions/external';
+import { menuBrowser, maximize, minimize, close } from '../../actions/external';
 import { getCurrentWebView } from '../../browser-util';
 
 /**
@@ -14,39 +14,33 @@ const NavBar = ({ page, dispatch }) => {
     return <div id="browser-navbar"></div>;
   }
 
-  const onBookmark = e => {
-    const webview = getCurrentWebView(e.target.ownerDocument);
-    const title = webview.getTitle();
-    const url = webview.getURL();
-    if (page.isBookmarked) {
-      unbookmark(url, dispatch);
-    } else {
-      bookmark(title, url, dispatch);
-    }
-  };
-
   return (
     <div id="browser-navbar">
+      <Btn title="Menu" icon="bars fa-lg"
+        onClick={() => menuBrowser(dispatch)} />
+
       <Btn title="Back" icon="arrow-left fa-lg"
         onClick={e => getCurrentWebView(e.target.ownerDocument).goBack()}
         disabled={!page.canGoBack} />
       <Btn title="Forward" icon="arrow-right fa-lg"
         onClick={e => getCurrentWebView(e.target.ownerDocument).goForward()}
         disabled={!page.canGoForward} />
-      <div className="input-group">
-        <Location {...{ page }} />
-        <Btn title="Refresh" icon="refresh"
-          onClick={e => getCurrentWebView(e.target.ownerDocument).reload()}
-          disabled={!page.canRefresh} />
-      </div>
-      <Btn title="Bookmark"
-        icon={page.isBookmarked ? 'star fa-lg' : 'star-o fa-lg'}
-        onClick={onBookmark} />
+      <Btn title="Refresh" icon="refresh"
+        onClick={e => getCurrentWebView(e.target.ownerDocument).reload()}
+        disabled={!page.canRefresh} />
+
+      <Location {...{ page }} />
+
       <Btn title="Home" icon="home fa-lg"
         onClick={e => getCurrentWebView(e.target.ownerDocument).goToIndex(0)}
         disabled={!page.canGoBack} />
-      <Btn title="Menu" icon="bars fa-lg"
-        onClick={() => menuBrowser(dispatch)} />
+
+      <Btn title="Minimize" icon="minus fa-lg"
+        onClick={minimize} />
+      <Btn title="Maximize" icon="square-o fa-lg"
+        onClick={maximize} />
+      <Btn title="Close" icon="times fa-lg"
+        onClick={close} />
     </div>
   );
 };

--- a/ui/browser/views/tabbar/tabbar.jsx
+++ b/ui/browser/views/tabbar/tabbar.jsx
@@ -2,7 +2,7 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import Tab from './tab.jsx';
-import { menuTabContext, maximize, minimize, close } from '../../actions/external';
+import { menuTabContext } from '../../actions/external';
 import { createTab, closeTab, setCurrentTab } from '../../actions/main-actions';
 import { TabBarDragDrop, TabDragDrop } from './dragdrop';
 
@@ -16,16 +16,6 @@ const TabBar = ({ pageOrder, pages, currentPageIndex, dispatch }) => {
   return (
     <div id="browser-tabs" dragzone="copy string:test/uri-list"
       {...barDragDrop.handlers}>
-
-      <a className="close" onClick={close}>
-        <i className="fa fa-circle" />
-      </a>
-      <a className="minimize" onClick={minimize}>
-        <i className="fa fa-circle" />
-      </a>
-      <a className="maximize" onClick={maximize}>
-        <i className="fa fa-circle" />
-      </a>
 
       {pageOrder.map((i) => {
         const page = pages.get(i);


### PR DESCRIPTION
…ove navbar above tabbar, make navbar drag the entire electron app, reorder the icons in navbar, move the OS system commands to Windows/right hand style, make the URL bar its own component

@joewalker / @victorporof  r?

![screen shot 2016-04-05 at 8 16 00 am](https://cloud.githubusercontent.com/assets/641267/14287191/ae413ed4-fb06-11e5-849b-9d5b16472cd5.png)
