### PR TITLE
Display the pages button with a counter

### DIFF
--- a/static/css/browser-navbar.css
+++ b/static/css/browser-navbar.css
@@ -64,3 +64,16 @@
   border-top-right-radius: 3px;
   border-bottom-right-radius: 3px;
 }
+
+#pages-button .page-count {
+  background-color: #4D4D4D;
+  color: #fff;
+  font-size: 70%;
+  width: 16px;
+  height: 14px;
+  padding-top: 2px;
+  text-align: center;
+  border-radius: 3px;
+  display: inline-block;
+  margin-right: 6px;
+}

--- a/test/ui/browser/views/tabbar/test-tab.js
+++ b/test/ui/browser/views/tabbar/test-tab.js
@@ -6,34 +6,32 @@ import { shallow } from 'enzyme';
 import Tab from '../../../../../ui/browser/views/tabbar/tab.jsx';
 import { Page } from '../../../../../ui/browser/model/index';
 
-describe('components', function() {
-  describe('NavBar', function() {
-    it('should render the basic case', function() {
-      const page = new Page({
-        location: 'https://www.mozilla.org',
-        title: 'Mozilla Home',
-      });
-      const onClick = expect.createSpy();
-
-      const wrapper = shallow(
-        <Tab page={page} isActive
-          onClose={expect.createSpy()}
-          onDragStart={expect.createSpy()}
-          onDragEnd={expect.createSpy()}
-          onDragEnter={expect.createSpy()}
-          onDrop={expect.createSpy()}
-          onClick={onClick}
-          onContextMenu={expect.createSpy()} />
-      );
-
-      expect(wrapper.html()).toEqual(
-        '<div class="active" draggable="true" title="Mozilla Home">' +
-          '<span>Mozilla Home</span>' +
-          '<a><i class="fa fa-close"></i></a>' +
-        '</div>');
-
-      wrapper.find('div').simulate('click');
-      expect(onClick).toHaveBeenCalled();
+describe('components - NavBar', function() {
+  it('should render the basic case', function() {
+    const page = new Page({
+      location: 'https://www.mozilla.org',
+      title: 'Mozilla Home',
     });
+    const onClick = expect.createSpy();
+
+    const wrapper = shallow(
+      <Tab page={page} isActive
+        onClose={expect.createSpy()}
+        onDragStart={expect.createSpy()}
+        onDragEnd={expect.createSpy()}
+        onDragEnter={expect.createSpy()}
+        onDrop={expect.createSpy()}
+        onClick={onClick}
+        onContextMenu={expect.createSpy()} />
+    );
+
+    expect(wrapper.html()).toEqual(
+      '<div class="active" draggable="true" title="Mozilla Home">' +
+        '<span>Mozilla Home</span>' +
+        '<a><i class="fa fa-close"></i></a>' +
+      '</div>');
+
+    wrapper.find('div').simulate('click');
+    expect(onClick).toHaveBeenCalled();
   });
 });

--- a/ui/browser/views/browser.jsx
+++ b/ui/browser/views/browser.jsx
@@ -28,6 +28,7 @@ class BrowserWindow extends Component {
     return (
       <div id="browser-chrome" className={"platform-" + platform} >
         <NavBar page={pages.get(currentPageIndex)}
+                pages={pages}
                 ipcRenderer={ipcRenderer} />
         <TabBar {...{ pages, pageOrder, currentPageIndex }} />
         <div id="content-area">

--- a/ui/browser/views/navbar/navbar.jsx
+++ b/ui/browser/views/navbar/navbar.jsx
@@ -9,7 +9,7 @@ import { getCurrentWebView } from '../../browser-util';
 /**
  * The section below the tabs containing the location bar and navigation buttons
  */
-const NavBar = ({ page, dispatch, ipcRenderer }) => {
+const NavBar = ({ page, pages, dispatch, ipcRenderer }) => {
   if (page == null) {
     return <div id="browser-navbar"></div>;
   }
@@ -19,6 +19,10 @@ const NavBar = ({ page, dispatch, ipcRenderer }) => {
       <Btn title="Menu" icon="bars fa-lg"
         onClick={() => menuBrowser(dispatch)} />
 
+      <a id="pages-button">
+        <span className="page-count">{pages.length}</span>
+        {"Pages"}
+      </a>
       <Btn title="Back" icon="arrow-left fa-lg"
         onClick={e => getCurrentWebView(e.target.ownerDocument).goBack()}
         disabled={!page.canGoBack} />


### PR DESCRIPTION
As per the mockup. Eventually this will open up the pages window, which is currently our TabBar. It does not yet hide the TabBar, as that'd be pretty weird at this point.
