### PR TITLE
Signal which versions of node should be used

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,5 +59,8 @@
     "webpack-dev-middleware": "1.5.1",
     "webpack-hot-middleware": "2.10.0",
     "webpack-merge": "0.8.4"
+  },
+  "engines": {
+    "node": ">=5.8.0"
   }
 }


### PR DESCRIPTION
Unfortunately, this only will provide info if someone's using engine strict in npm, but a good signal to have if someone can't get things started.
