### PR TITLE
Issue #27: Establish hidden `BrowserWindow` for main process communication

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -10,6 +10,11 @@ Node code that runs in the main process and has access to Electron APIs. Spawns 
 
 Services used in the main-process.
 
+### services/hidden-window
+
+Long lived hidden `BrowserWindow` instance that exposes HTML5 events
+and APIs from a background content process to the main process.
+
 ## shared
 
 Utilities and modules used by both main-process/node code and render-process/browser code.

--- a/app/main/main.js
+++ b/app/main/main.js
@@ -29,6 +29,9 @@ const globalShortcut = electron.globalShortcut;
 const root = path.dirname(__dirname);
 const staticDir = path.join(__dirname, '..', '..', 'static');
 
+// Keep a global reference to the hidden window.
+const hiddenWindow = require('../services/hidden-window');
+
 // Keep a global references of the window objects, if you don't, the windows will
 // be closed automatically when the JavaScript object is garbage collected.
 const mainWindows = [];

--- a/app/services/hidden-window.js
+++ b/app/services/hidden-window.js
@@ -1,0 +1,56 @@
+/* eslint no-console: 0 */
+
+/**
+ * The Electron main process does not receive many HTML5 events, including
+ * online and offline status changes.  The recommended approach is to
+ * pass-through the HTML5 events from a content process to the main process: see
+ * https://github.com/electron/electron/blob/master/docs/tutorial/online-offline-events.md.
+ *
+ * We implement this approach here in a single, extensible place.  We maintain a
+ * single hidden background content renderer, pass-through events, and expose an
+ * event emitter and simple API.
+ */
+
+const { isProduction } = require('../../shared/util');
+
+const { app, BrowserWindow, ipcMain } = require('electron');
+
+const events = require('events');
+
+// Set once when the app is ready, never set again, never cleaned up.  Kept
+// alive by `hiddenWindow`.
+let hiddenBrowserWindow;
+
+const hiddenWindow = new events.EventEmitter();
+
+module.exports = hiddenWindow;
+
+app.on('ready', function() {
+  console.log('ready');
+  hiddenBrowserWindow = new BrowserWindow({ width: 0, height: 0, show: false });
+  hiddenBrowserWindow.loadURL('file://' + __dirname + '/hidden-window/hidden-window.html');
+
+  // // To debug the hidden window JS, uncomment the following:
+  // if (!isProduction()) {
+  //   hiddenBrowserWindow.openDevTools({ detach: true });
+  // }
+
+  // Maintain a reference to keep `hiddenBrowserWindow` alive for as long as
+  // `hiddenWindow` lives.
+  hiddenWindow._hiddenBrowserWindow = hiddenBrowserWindow;
+});
+
+let onLine;
+Object.defineProperty(hiddenWindow, 'onLine', {
+    get: function () {
+      return onLine;
+    }
+});
+
+// Expose a navigator.onLine alike, and radiate 'online' and 'offline'
+// events through the `hiddenWindow`.
+ipcMain.on('online-status-changed', function(event, newOnLine) {
+  console.log('online-status-changed');
+  onLine = newOnLine;
+  hiddenWindow.emit(newOnLine ? 'online' : 'offline');
+});

--- a/app/services/hidden-window/hidden-window.html
+++ b/app/services/hidden-window/hidden-window.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <script src="online-status.js"></script>
+  </body>
+</html>

--- a/app/services/hidden-window/online-status.js
+++ b/app/services/hidden-window/online-status.js
@@ -1,0 +1,10 @@
+const ipcRenderer = require('electron').ipcRenderer;
+
+var updateOnlineStatus = function() {
+  ipcRenderer.send('online-status-changed', navigator.onLine);
+};
+
+window.addEventListener('online',  updateOnlineStatus);
+window.addEventListener('offline',  updateOnlineStatus);
+
+updateOnlineStatus();

--- a/build/run.js
+++ b/build/run.js
@@ -16,5 +16,5 @@ module.exports = env => cb => {
     command = `NODE_ENV=production ${command}`;
   }
   console.log(`Executing command: ${command}`);
-  exec(command, err => err ? cb(err) : cb());
+  exec(command, err => err ? cb(err) : cb()).stdout.pipe(process.stdout);
 };


### PR DESCRIPTION
@Mossop comments?

It's not clear that a separate directory and scripts will pay off, but it's done.

I'm not 100% clear on the best way to have A keep a reference to B *without* exposing the reference.  It's also not clear to me when module level const defines go out of scope -- perhaps the efforts I made aren't actually necessary?  (Or effective?)