### PR TITLE
Make the navbar more of a presentation component that does not define

### DIFF
--- a/test/ui/browser/views/navbar/test-navbar.js
+++ b/test/ui/browser/views/navbar/test-navbar.js
@@ -1,10 +1,6 @@
 // Any copyright is dedicated to the Public Domain.
 // http://creativecommons.org/publicdomain/zero/1.0/
 
-// We need to make the actions/external not depend on electron for this to
-// be testable outside of electron, but otherwise we could do ...
-
-/*
 import expect from 'expect';
 import React from 'react';
 import { shallow } from 'enzyme';
@@ -12,24 +8,67 @@ import { shallow } from 'enzyme';
 import NavBar from '../../../../../ui/browser/views/navbar/navbar.jsx';
 import { Page } from '../../../../../ui/browser/model/index';
 
-describe('components', function() {
+function createSpyProps() {
+  return {
+    page: expect.createSpy(),
+    ipcRenderer: Object.create(null),
+    navBack: expect.createSpy(),
+    navForward: expect.createSpy(),
+    navRefresh: expect.createSpy(),
+    minimize: expect.createSpy(),
+    maximize: expect.createSpy(),
+    close: expect.createSpy(),
+    openMenu: expect.createSpy(),
+    bookmark: expect.createSpy(),
+    unbookmark: expect.createSpy(),
+    onLocationChange: expect.createSpy(),
+    onLocationContextMenu: expect.createSpy(),
+    onLocationReset: expect.createSpy(),
+  };
+}
+
+describe('NavBar', function() {
   describe('NavBar', function() {
     it('should render the empty case', function() {
+      let props = createSpyProps();
+      delete props.page;
       const wrapper = shallow(
-        <NavBar page={null} dispatch={expect.createSpy()} />
+        <NavBar {...props} />
       );
 
       expect(wrapper.html()).toEqual('<div id="browser-navbar"></div>');
     });
+  });
 
-    it('should call onDelete', function() {
-      const page = new Page({ location: 'https://www.mozilla.org' });
-      const wrapper = shallow(
-        <NavBar page={page} dispatch={expect.createSpy()} />
-      );
-
-      expect(wrapper.html()).toEqual('...');
-    });
+  describe('Menu button', function() {
+    it('calls handler');
+  });
+  describe('Back button', function() {
+    it('calls handler');
+    it('is disabled if page cannot go back');
+    it('is not disabled if page can go back');
+  });
+  describe('Forward button', function() {
+    it('calls handler');
+    it('is disabled if page cannot go forward');
+    it('is not disabled if page can go forward');
+  });
+  describe('Refresh button', function() {
+    it('calls handler');
+    it('is disabled if page cannot be refreshed');
+    it('is not disabled if page can be refreshed');
+  });
+  describe('Pages button', function() {
+    it('calls handler');
+    it('has correct page count');
+  });
+  describe('Minimize button ', function() {
+    it('calls handler');
+  });
+  describe('Maximize button ', function() {
+    it('calls handler');
+  });
+  describe('Close button ', function() {
+    it('calls handler');
   });
 });
-*/

--- a/ui/browser/actions/external.js
+++ b/ui/browser/actions/external.js
@@ -196,7 +196,7 @@ export function bookmark(title, url, dispatch) {
   browserDB.bookmarks.add({ url, title, created: new Date() });
   dispatch(setPageDetails(-1, { isBookmarked: true }));
 
-  this.updateMenu();
+  updateMenu();
 }
 
 /**
@@ -206,7 +206,7 @@ export function unbookmark(url, dispatch) {
   browserDB.bookmarks.where('url').equals(url).delete();
   dispatch(setPageDetails(-1, { isBookmarked: false }));
 
-  this.updateMenu();
+  updateMenu();
 }
 
 /**

--- a/ui/browser/views/app.jsx
+++ b/ui/browser/views/app.jsx
@@ -17,12 +17,15 @@ import BrowserWindow from './browser.jsx';
 import * as actions from '../actions/main-actions';
 import { ipcRenderer } from 'electron';
 
-export const App = ({ state }) => (
-  <BrowserWindow pages={state.pages}
-    pageOrder={state.pageOrder}
-    currentPageIndex={state.currentPageIndex}
-    ipcRenderer={ipcRenderer} />
-);
+export const App = function({ state, dispatch }) {
+  return (
+    <BrowserWindow pages={state.pages}
+      pageOrder={state.pageOrder}
+      currentPageIndex={state.currentPageIndex}
+      ipcRenderer={ipcRenderer}
+      dispatch={dispatch} />
+  );
+}
 
 App.propTypes = {
   state: PropTypes.object.isRequired,
@@ -38,4 +41,4 @@ function mapDispatchToProps(dispatch) {
   };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(App);
+export default connect(mapStateToProps)(App);

--- a/ui/browser/views/navbar/location.jsx
+++ b/ui/browser/views/navbar/location.jsx
@@ -11,10 +11,7 @@ specific language governing permissions and limitations under the License.
 */
 
 import React, { PropTypes, Component } from 'react';
-import { connect } from 'react-redux';
 import Btn from './btn.jsx';
-import { menuLocationContext, bookmark, unbookmark } from '../../actions/external';
-import { setLocation } from '../../actions/main-actions';
 import { fixURL, getCurrentWebView } from '../../browser-util';
 
 /**
@@ -40,13 +37,13 @@ class Location extends Component {
       webview.setAttribute('src', location);
     } else if (ev.keyCode === 27) { // esc
       // Restore back to page location and reset userTyped
-      this.props.dispatch(setLocation());
+      this.props.onLocationReset();
       ev.target.select();
     }
   }
 
   render() {
-    const { page, dispatch } = this.props;
+    const { page, onLocationChange, onLocationContextMenu, bookmark, unbookmark } = this.props;
     const value = page.userTyped !== null ? page.userTyped : page.location;
 
     const onBookmark = e => {
@@ -54,9 +51,9 @@ class Location extends Component {
       const title = webview.getTitle();
       const url = webview.getURL();
       if (page.isBookmarked) {
-        unbookmark(url, dispatch);
+        unbookmark(url);
       } else {
-        bookmark(title, url, dispatch);
+        bookmark(title, url);
       }
     };
 
@@ -64,9 +61,9 @@ class Location extends Component {
       <div id="browser-location-bar">
         <input id="urlbar-input" type="text" ref="input"
           value={value}
-          onChange={ev => dispatch(setLocation(ev.target.value))}
+          onChange={onLocationChange}
           onClick={ev => ev.target.select()}
-          onContextMenu={ev => menuLocationContext(ev.target, dispatch)}
+          onContextMenu={onLocationContextMenu}
           onKeyDown={this.handleKeyDown} />
 
         <Btn title="Bookmark"
@@ -79,8 +76,12 @@ class Location extends Component {
 
 Location.propTypes = {
   page: PropTypes.object.isRequired,
-  dispatch: PropTypes.func.isRequired,
+  onLocationChange: PropTypes.func.isRequired,
+  onLocationContextMenu: PropTypes.func.isRequired,
+  onLocationReset: PropTypes.func.isRequired,
+  bookmark: PropTypes.func.isRequired,
+  unbookmark: PropTypes.func.isRequired,
   ipcRenderer: PropTypes.object.isRequired,
 };
 
-export default connect()(Location);
+export default Location;

--- a/ui/browser/views/navbar/navbar.jsx
+++ b/ui/browser/views/navbar/navbar.jsx
@@ -10,60 +10,76 @@ CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 */
 
-import React, { PropTypes } from 'react';
-import { connect } from 'react-redux';
+import React, { PropTypes, Component } from 'react';
 import Btn from './btn.jsx';
 import Location from './location.jsx';
-import { menuBrowser, maximize, minimize, close } from '../../actions/external';
-import { getCurrentWebView } from '../../browser-util';
 
 /**
  * The section below the tabs containing the location bar and navigation buttons
  */
-const NavBar = ({ page, pages, dispatch, ipcRenderer }) => {
-  if (page == null) {
-    return <div id="browser-navbar"></div>;
+class NavBar extends Component {
+  render() {
+
+    const {
+      navBack, navForward, navRefresh, page, pages, openMenu, ipcRenderer, minimize, maximize, close,
+      setLocation, bookmark, unbookmark, onLocationChange, onLocationContextMenu, onLocationReset
+    } = this.props;
+
+    if (page == null) {
+      return <div id="browser-navbar"></div>;
+    }
+
+    return (
+      <div id="browser-navbar">
+        <Btn title="Menu" icon="bars fa-lg"
+          onClick={openMenu} />
+
+        <a id="pages-button">
+          <span className="page-count">{pages.size}</span>
+          {"Pages"}
+        </a>
+        <Btn title="Back" icon="arrow-left fa-lg"
+          onClick={navBack}
+          disabled={!page.canGoBack} />
+        <Btn title="Forward" icon="arrow-right fa-lg"
+          onClick={navForward}
+          disabled={!page.canGoForward} />
+        <Btn title="Refresh" icon="refresh"
+          onClick={navRefresh}
+          disabled={!page.canRefresh} />
+
+        <Location {
+          ...{page, ipcRenderer, bookmark, unbookmark, onLocationChange, onLocationContextMenu, onLocationReset}
+        } />
+
+        <Btn title="Minimize" icon="minus fa-lg"
+          onClick={minimize} />
+        <Btn title="Maximize" icon="square-o fa-lg"
+          onClick={maximize} />
+        <Btn title="Close" icon="times fa-lg"
+          onClick={close} />
+      </div>
+    );
   }
-
-  return (
-    <div id="browser-navbar">
-      <Btn title="Menu" icon="bars fa-lg"
-        onClick={() => menuBrowser(dispatch)} />
-
-      <a id="pages-button">
-        <span className="page-count">{pages.size}</span>
-        {"Pages"}
-      </a>
-      <Btn title="Back" icon="arrow-left fa-lg"
-        onClick={e => getCurrentWebView(e.target.ownerDocument).goBack()}
-        disabled={!page.canGoBack} />
-      <Btn title="Forward" icon="arrow-right fa-lg"
-        onClick={e => getCurrentWebView(e.target.ownerDocument).goForward()}
-        disabled={!page.canGoForward} />
-      <Btn title="Refresh" icon="refresh"
-        onClick={e => getCurrentWebView(e.target.ownerDocument).reload()}
-        disabled={!page.canRefresh} />
-
-      <Location {...{ page, ipcRenderer }} />
-
-      <Btn title="Home" icon="home fa-lg"
-        onClick={e => getCurrentWebView(e.target.ownerDocument).goToIndex(0)}
-        disabled={!page.canGoBack} />
-
-      <Btn title="Minimize" icon="minus fa-lg"
-        onClick={minimize} />
-      <Btn title="Maximize" icon="square-o fa-lg"
-        onClick={maximize} />
-      <Btn title="Close" icon="times fa-lg"
-        onClick={close} />
-    </div>
-  );
 };
 
 NavBar.propTypes = {
   page: PropTypes.object,
-  dispatch: PropTypes.func.isRequired,
   ipcRenderer: PropTypes.object.isRequired,
+  navBack: PropTypes.func.isRequired,
+  navForward: PropTypes.func.isRequired,
+  navRefresh: PropTypes.func.isRequired,
+  minimize: PropTypes.func.isRequired,
+  maximize: PropTypes.func.isRequired,
+  close: PropTypes.func.isRequired,
+  openMenu: PropTypes.func.isRequired,
+
+  // For <Location>
+  bookmark: PropTypes.func.isRequired,
+  unbookmark: PropTypes.func.isRequired,
+  onLocationChange: PropTypes.func.isRequired,
+  onLocationContextMenu: PropTypes.func.isRequired,
+  onLocationReset: PropTypes.func.isRequired,
 };
 
-export default connect()(NavBar);
+export default NavBar;

--- a/ui/browser/views/page/page.jsx
+++ b/ui/browser/views/page/page.jsx
@@ -11,7 +11,6 @@ specific language governing permissions and limitations under the License.
 */
 
 import React, { PropTypes, Component } from 'react';
-import { connect } from 'react-redux';
 
 import Status from './status.jsx';
 import Search from './search.jsx';
@@ -62,7 +61,7 @@ Page.propTypes = {
   dispatch: PropTypes.func.isRequired,
 };
 
-export default connect()(Page);
+export default Page;
 
 /**
  * WebView wasn't designed for React...

--- a/ui/browser/views/tabbar/tabbar.jsx
+++ b/ui/browser/views/tabbar/tabbar.jsx
@@ -11,7 +11,6 @@ specific language governing permissions and limitations under the License.
 */
 
 import React, { PropTypes } from 'react';
-import { connect } from 'react-redux';
 import Tab from './tab.jsx';
 import { menuTabContext } from '../../actions/external';
 import { createTab, closeTab, setCurrentTab } from '../../actions/main-actions';
@@ -61,4 +60,4 @@ TabBar.propTypes = {
   dispatch: PropTypes.func.isRequired,
 };
 
-export default connect()(TabBar);
+export default TabBar;


### PR DESCRIPTION
its own handlers, and does not receive a dispatch method. Also clean up
the react-redux connect method used for some components and not others,
and only handle this at the root BrowserWindow state.


(Having to recreate this PR due to repo name changes, privacy changes, etc), original: https://github.com/mozilla/tofino/pull/34