### PR TITLE
Remove electron from .gitignore r=victorporof

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /.idea/
 npm-debug.log
-electron
 node_modules
 dist
 *.sw*


### PR DESCRIPTION
Since we no longer use a custom built of electron, we no longer need electron in .gitignore