### PR TITLE
Remove `globalReturn` from the ecmaFeatures in .eslintrc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,8 +6,7 @@
   "parserOptions": {
     "ecmaVersion": 6,
     "ecmaFeatures": {
-      "jsx": true,
-      "globalReturn": true
+      "jsx": true
     }
   },
 

--- a/.eslintrc
+++ b/.eslintrc
@@ -18,7 +18,7 @@
     "new-cap": ["error", {
       "capIsNewExceptions": ["Immutable.List", "Immutable.Map", "Immutable.Record", "Immutable.Set"]
     }],
-    "func-names": "off",
+    "func-names": ["off"],
     "space-before-function-paren": ["error", "never"],
     "no-param-reassign": ["off"],
     "no-return-assign": ["off"],


### PR DESCRIPTION
We probably shouldn’t ever use it

Signed-off-by: Victor Porof <vporof@mozilla.com>