### PR TITLE
Middle click to close tabs. Fixes #106. r=victorporof,phlsa

### DIFF
--- a/ui/browser/views/tabbar/tabbar.jsx
+++ b/ui/browser/views/tabbar/tabbar.jsx
@@ -40,7 +40,7 @@ const TabBar = ({ pageOrder, pages, currentPageIndex, dispatch, pageAreaVisible 
           <Tab key={`browser-tab-${i}`} className={`browser-tab-${i}`}
             isActive={currentPageIndex === i}
             page={page}
-            onClick={() => dispatch(setCurrentTab(i))}
+            onClick={e => dispatch(e.button === 1 ? closeTab(i) : setCurrentTab(i))}
             onContextMenu={() => menuTabContext(i, dispatch)}
             onClose={e => {
               e.preventDefault();


### PR DESCRIPTION
> (Here's another shot at tab closing with middle click)

Introduces a clickTab function in main-actions that allows for clicks
to dispatch different events based on the button number.