### PR TITLE
Extend .eslintrc with recommended react rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,5 @@
 {
-  "extends": "airbnb",
+  "extends": ["airbnb", "plugin:react/recommended"],
 
   "parser": "babel-eslint",
 
@@ -34,6 +34,12 @@
       "allowArrayStart": true
     }],
     "react/jsx-closing-bracket-location": ["error", "after-props"],
+    "react/jsx-indent": ["error", 2],
+    "react/jsx-indent-props": ["error", 2],
+    "react/jsx-max-props-per-line": ["error", { "maximum": 1 }],
+    "react/jsx-equals-spacing": ["error", "never"],
+    "react/jsx-curly-spacing": ["error", "never"],
+    "react/jsx-handler-names": ["error"],
     "react/prefer-es6-class": ["off"],
   }
 }

--- a/test/ui/browser/views/navbar/test-btn.js
+++ b/test/ui/browser/views/navbar/test-btn.js
@@ -10,38 +10,56 @@ const noop = function() {};
 
 describe('Btn', () => {
   it('sets `id` if given', () => {
-    const wrapper = shallow(<Btn id={'my-btn'} title={'my title'} clickHandler={noop} />);
+    const wrapper = shallow(
+      <Btn id={'my-btn'}
+        title={'my title'}
+        clickHandler={noop} />);
     expect(wrapper.prop('id')).toEqual('my-btn');
   });
   it('has `disabled` prop if given', () => {
-    const wrapper = shallow(<Btn disabled title={'my title'} clickHandler={noop} />);
+    const wrapper = shallow(
+      <Btn disabled
+        title={'my title'}
+        clickHandler={noop} />);
     expect(wrapper.prop('disabled')).toEqual(true);
   });
   it('does not have `disabled` if not given', () => {
-    const wrapper = shallow(<Btn title={'my title'} clickHandler={noop} />);
+    const wrapper = shallow(
+      <Btn title={'my title'}
+        clickHandler={noop} />);
     expect(wrapper.prop('disabled')).toEqual(void 0);
   });
   it('sets `title`', () => {
-    const wrapper = shallow(<Btn title={'my title'} clickHandler={noop} />);
+    const wrapper = shallow(
+      <Btn title={'my title'}
+        clickHandler={noop} />);
     expect(wrapper.prop('title')).toEqual('my title');
   });
   it('fires the click handler on click', () => {
     const spy = expect.createSpy();
-    const wrapper = shallow(<Btn title={'my title'} clickHandler={spy} />);
+    const wrapper = shallow(
+      <Btn title={'my title'}
+        clickHandler={spy} />);
     expect(spy).toNotHaveBeenCalled();
     wrapper.simulate('click');
     expect(spy).toHaveBeenCalled();
   });
   it('does not fire the click handler on click when disabled', () => {
     const spy = expect.createSpy();
-    const wrapper = shallow(<Btn disabled title={'my title'} clickHandler={spy} />);
+    const wrapper = shallow(
+      <Btn disabled
+        title={'my title'}
+        clickHandler={spy} />);
     expect(spy).toNotHaveBeenCalled();
     wrapper.simulate('click');
     expect(spy).toNotHaveBeenCalled();
   });
 
   it('sets `id` if given', () => {
-    const wrapper = shallow(<Btn image={'some-file.svg'} title={'my title'} clickHandler={noop} />);
+    const wrapper = shallow(
+      <Btn image={'some-file.svg'}
+        title={'my title'}
+        clickHandler={noop} />);
     expect(JSON.stringify(wrapper.prop('style'))).toContain('some-file.svg');
   });
 });

--- a/test/ui/browser/views/tabbar/test-tab.js
+++ b/test/ui/browser/views/tabbar/test-tab.js
@@ -17,7 +17,8 @@ describe('components - NavBar', () => {
     const onClick = expect.createSpy();
 
     const wrapper = shallow(
-      <Tab page={page} isActive
+      <Tab isActive
+        page={page}
         onClose={expect.createSpy()}
         onDragStart={expect.createSpy()}
         onDragEnd={expect.createSpy()}

--- a/ui/browser/views/browser.jsx
+++ b/ui/browser/views/browser.jsx
@@ -55,7 +55,8 @@ class BrowserWindow extends Component {
     const setPageAreaVisibility = (visible) => dispatch(setPageAreaVisibilityAction(visible));
 
     return (
-      <div id="browser-chrome" className={`platform-${platform}`} >
+      <div id="browser-chrome"
+        className={`platform-${platform}`} >
         <NavBar page={pages.get(currentPageIndex)}
           {...{ pages, navBack, navForward, navRefresh, minimize, maximize,
             close, openMenu, onLocationChange, onLocationContextMenu,
@@ -65,7 +66,8 @@ class BrowserWindow extends Component {
         <div id="content-area">
           {pages.map((page, pageIndex) => (
             <Page key={`page-${pageIndex}`}
-              page={page} pageIndex={pageIndex}
+              page={page}
+              pageIndex={pageIndex}
               isActive={pageIndex === currentPageIndex}
               browserDB={browserDB}
               dispatch={dispatch} />

--- a/ui/browser/views/navbar/location.jsx
+++ b/ui/browser/views/navbar/location.jsx
@@ -59,7 +59,9 @@ class Location extends Component {
 
     return (
       <div id="browser-location-bar">
-        <input id="urlbar-input" type="text" ref="input"
+        <input ref="input"
+          id="urlbar-input"
+          type="text"
           value={value}
           onChange={onLocationChange}
           clickHandler={ev => ev.target.select()}

--- a/ui/browser/views/navbar/navbar.jsx
+++ b/ui/browser/views/navbar/navbar.jsx
@@ -31,13 +31,17 @@ function NavBar(props) {
   return (
     <div id="browser-navbar">
       <Btn id="browser-navbar-menu"
-        title="Menu" image="glyph-menu-16.svg"
+        title="Menu"
+        image="glyph-menu-16.svg"
         clickHandler={openMenu} />
 
-      <Btn id="pages-button" title="Pages"
+      <Btn id="pages-button"
+        title="Pages"
         active={pageAreaVisible}
         clickHandler={() => { setPageAreaVisibility(!pageAreaVisible); }}>
-          <span id="browser-navbar-pages-count" style={{
+
+        <span id="browser-navbar-pages-count"
+          style={{
             backgroundColor: '#4d4d4d',
             color: '#fff',
             fontSize: '10px',
@@ -48,21 +52,29 @@ function NavBar(props) {
             borderRadius: '3px',
             display: 'inline-block',
             margin: '0px 6px 0px 0px',
-          }}>{pages.size}</span>
-          <span style={{
-            fontSize: '12px',
-          }}>{"Pages"}</span>
+          }}>
+          {pages.size}
+        </span>
+        <span style={{
+          fontSize: '12px',
+        }}>
+          {"Pages"}
+        </span>
       </Btn>
+
       <Btn id="browser-navbar-back"
-        title="Back" image="glyph-arrow-nav-back-16.svg"
+        title="Back"
+        image="glyph-arrow-nav-back-16.svg"
         clickHandler={navBack}
         disabled={!page.canGoBack} />
       <Btn id="browser-navbar-forward"
-        title="Forward" image="glyph-arrow-nav-forward-16.svg"
+        title="Forward"
+        image="glyph-arrow-nav-forward-16.svg"
         clickHandler={navForward}
         disabled={!page.canGoForward} />
       <Btn id="browser-navbar-refresh"
-        title="Refresh" image="glyph-arrow-reload-16.svg"
+        title="Refresh"
+        image="glyph-arrow-reload-16.svg"
         clickHandler={navRefresh}
         disabled={!page.canRefresh} />
 
@@ -71,13 +83,16 @@ function NavBar(props) {
           onLocationChange, onLocationContextMenu, onLocationReset }
       } />
       <Btn id="browser-navbar-minimize"
-        title="Minimize" image="glyph-window-minimize-16.svg"
+        title="Minimize"
+        image="glyph-window-minimize-16.svg"
         clickHandler={minimize} />
       <Btn id="browser-navbar-maximize"
-        title="Maximize" image="glyph-window-maximize-16.svg"
+        title="Maximize"
+        image="glyph-window-maximize-16.svg"
         clickHandler={maximize} />
       <Btn id="browser-navbar-close"
-        title="Close" image="glyph-window-close-16.svg"
+        title="Close"
+        image="glyph-window-close-16.svg"
         clickHandler={close} />
     </div>
   );

--- a/ui/browser/views/page/page.jsx
+++ b/ui/browser/views/page/page.jsx
@@ -41,7 +41,8 @@ class Page extends Component {
     const { page, isActive, dispatch, pageIndex } = this.props;
 
     return (
-      <div id="browser-page" className={isActive ? 'visible' : 'hidden'}>
+      <div id="browser-page"
+        className={isActive ? 'visible' : 'hidden'}>
         <Search isActive={page.isSearching} />
         <web-view className={`webview-${pageIndex}`}
           ref={node => { if (node != null) this.webview = node; }}

--- a/ui/browser/views/page/search.jsx
+++ b/ui/browser/views/page/search.jsx
@@ -17,8 +17,11 @@ import { inPageSearch } from '../../actions/external';
  * In page search
  */
 const Search = ({ isActive }) => (
-  <div id="browser-page-search" className={isActive ? 'visible' : 'hidden'}>
-    <input type="text" placeholder="Search..." onKeyDown={inPageSearch} />
+  <div id="browser-page-search"
+    className={isActive ? 'visible' : 'hidden'}>
+    <input type="text"
+      placeholder="Search..."
+      onKeyDown={inPageSearch} />
   </div>
 );
 

--- a/ui/browser/views/tabbar/tabbar.jsx
+++ b/ui/browser/views/tabbar/tabbar.jsx
@@ -29,7 +29,8 @@ const TabBar = ({ pageOrder, pages, currentPageIndex, dispatch, pageAreaVisible 
   }
 
   return (
-    <div id="browser-tabs" dragzone="copy string:test/uri-list"
+    <div id="browser-tabs"
+      dragzone="copy string:test/uri-list"
       {...barDragDrop.handlers}>
 
       {pageOrder.map((i) => {
@@ -37,7 +38,8 @@ const TabBar = ({ pageOrder, pages, currentPageIndex, dispatch, pageAreaVisible 
         const dragDrop = new TabDragDrop(page, pageOrder, i);
 
         return (
-          <Tab key={`browser-tab-${i}`} className={`browser-tab-${i}`}
+          <Tab key={`browser-tab-${i}`}
+            className={`browser-tab-${i}`}
             isActive={currentPageIndex === i}
             page={page}
             onClick={() => dispatch(setCurrentTab(i))}
@@ -51,7 +53,8 @@ const TabBar = ({ pageOrder, pages, currentPageIndex, dispatch, pageAreaVisible 
         );
       })}
 
-      <a className="newtab" onClick={() => dispatch(createTab())}>
+      <a className="newtab"
+        onClick={() => dispatch(createTab())}>
         <i className="fa fa-plus" />
       </a>
     </div>


### PR DESCRIPTION
Since the react-eslint plugin already extends a "good practices" recommended configuration, we should extend that in our .eslintrc. 

Additionally, we seem to already be following a pattern with our current components. It'd be a good idea to make the current style a standard we keep in the future. There are many rules we could add (see https://github.com/yannickcr/eslint-plugin-react), but I just picked a few:

* react/jsx-indent -- make sure we indent jsx markup with 2 spaces (already the case everywhere)
* react/jsx-indent-props -- make sure we indent every "attribute" (prop) with 2 spaces (already the case almost everywhere)
* react/jsx-max-props-per-line -- make sure we have one "attribute" (prop) on every line (already the case almost everywhere)
* react/jsx-equals-spacing and react/jsx-curly-spacing -- make sure we have prop={value} without spaces (already the case everywhere)
* react/jsx-handler-names -- make sure we adhere to the onFoo={this.handleFoo} de-facto convention for naming event handlers

Ping @joewalker for review.

