### PR TITLE
Make the navbar clickable again on windows.  r=jsantell

### DIFF
--- a/static/css/browser-navbar.css
+++ b/static/css/browser-navbar.css
@@ -13,6 +13,6 @@
   -webkit-app-region: drag;
 }
 
-#browser-navbar a, #browser-navbar input {
+#browser-navbar a, #browser-navbar input, #browser-navbar button, #browser-location-bar {
   -webkit-app-region: no-drag;
 }


### PR DESCRIPTION
Updates the fix in #56 for the recent navbar changes.