### PR TITLE
Take a dependency on sqlite, stubbing out a storage module.

### DIFF
--- a/app/services/storage.js
+++ b/app/services/storage.js
@@ -10,21 +10,27 @@ CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 */
 
+/* eslint no-console: 0 */
+
 /**
- * Disable the eslint "strict" and "no-commonjs" rules, since this is a script
- * that runs in node without any babel support, so it's not not a module
- * implicitly running in strict mode, and we can't use the import syntax.
+ * The storage module that makes up the majority of the profile service.
+ *
+ * @module Storage
  */
 
-/* eslint-disable strict */
-/* eslint-disable import/no-commonjs */
+import sqlite3 from 'sqlite3';
 
-'use strict';
+export function open(path) {
+  sqlite3.verbose();
 
-// Must go before any require statements.
-const browserStartTime = Date.now();
+  const db = new sqlite3.Database(path);
+  db.get('PRAGMA user_version', (err, row) => {
+    if (err) {
+      console.log('Unable to fetch DB user_version.');
+      return;
+    }
+    console.log(`User version: ${row.user_version}.`);
+  });
 
-require('babel-polyfill');
-require('babel-register')();
-
-require('./browser').default(browserStartTime);
+  return db;
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "node build/main.js --run-dev",
     "package": "node build/main.js --package",
     "test": "mocha",
-    "postinstall": "electron-rebuild"
+    "postinstall": "electron-rebuild -f"
   },
   "license": "Apache-2.0",
   "dependencies": {
@@ -30,7 +30,8 @@
     "react-redux": "4.4.1",
     "redux": "3.3.1",
     "redux-logger": "2.6.1",
-    "request": "2.71.0"
+    "request": "2.71.0",
+    "sqlite3": "3.1.3"
   },
   "devDependencies": {
     "electron-packager": "5.2.1",


### PR DESCRIPTION
I also fixed a lint warning in `main.js`, and stubbed out usage so we'll die hard if loading the module fails. That part'll get overwritten quite quickly, but until then we have `foo.db`.

You'll need to run `npm install` again to pull in `sqlite3`.