### PR TITLE
Expose build failures (#20)

### DIFF
--- a/build/main.js
+++ b/build/main.js
@@ -14,12 +14,18 @@
 require('babel-polyfill');
 require('babel-register')();
 
+const handleTaskFailed = e => {
+  /* eslint no-console: 0 */
+  console.error('Build failed.');
+  console.error(e.stack);
+};
+
 const Tasks = require('./tasks').default;
 
 if (~process.argv.indexOf('--run')) {
-  Tasks.run();
+  Tasks.run().then(null, handleTaskFailed);
 } else if (~process.argv.indexOf('--run-dev')) {
-  Tasks.runDev();
+  Tasks.runDev().then(null, handleTaskFailed);
 } else if (~process.argv.indexOf('--package')) {
-  Tasks.package();
+  Tasks.package().then(null, handleTaskFailed);
 }

--- a/build/task-build.js
+++ b/build/task-build.js
@@ -9,10 +9,11 @@ import { development } from '../build-config';
 
 export default () => new Promise((resolve, reject) => {
   const config = development ? webpackDevConfig : webpackProdConfig;
-  try {
-    const compiler = webpack(config);
-    compiler.run(resolve);
-  } catch (err) {
-    reject(err);
-  }
+  const compiler = webpack(config);
+  compiler.run(resolve, err => {
+    if (err) {
+      reject(err);
+    }
+    resolve();
+  });
 });


### PR DESCRIPTION
Signed-off-by: Victor Porof <vporof@mozilla.com>

Indeed existing promise rejections weren't handled in the top level build code, and I found a few other call sites that didn't properly reject or throw when errors occurred.

Ping @jsantell for review.