### PR TITLE
Test actions effects on state

### DIFF
--- a/test/ui/browser/actions/test-attach-tab.js
+++ b/test/ui/browser/actions/test-attach-tab.js
@@ -1,0 +1,14 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+import expect from 'expect'; // eslint-disable-line
+import configureStore from '../../../../ui/browser/store/store';
+import * as actions from '../../../../ui/browser/actions/main-actions'; // eslint-disable-line
+
+describe('Action - ATTACH_TAB', () => {
+  beforeEach(function() {
+    this.store = configureStore();
+  });
+
+  it('Should attach tab');
+});

--- a/test/ui/browser/actions/test-close-tab.js
+++ b/test/ui/browser/actions/test-close-tab.js
@@ -1,0 +1,75 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+import expect from 'expect';
+import configureStore from '../../../../ui/browser/store/store';
+import * as actions from '../../../../ui/browser/actions/main-actions';
+
+describe('Action - CLOSE_TAB', () => {
+  beforeEach(function() {
+    this.store = configureStore();
+    this.store.dispatch(actions.createTab('https://moz.org/1'));
+    this.store.dispatch(actions.createTab('https://moz.org/2'));
+    this.store.dispatch(actions.createTab('https://moz.org/3'));
+    expect(this.store.getState().currentPageIndex).toEqual(3);
+    expect(this.store.getState().pages.size).toEqual(4);
+  });
+
+  it('Should maintain tab selection when destroying a tab before the selected tab', function() {
+    const { getState, dispatch } = this.store;
+
+    dispatch(actions.closeTab(1));
+    expect(getState().pages.size).toEqual(3);
+    expect(getState().pages.get(1).location).toEqual('https://moz.org/2');
+    expect(getState().currentPageIndex).toEqual(2,
+      'CLOSE_TAB does not update selected tab if the tab destroyed was not selected.');
+  });
+
+  it('Should maintain tab selection when destroying a tab after the selected tab', function() {
+    const { getState, dispatch } = this.store;
+
+    dispatch(actions.setCurrentTab(1));
+    dispatch(actions.closeTab(3));
+
+    expect(getState().pages.size).toEqual(3);
+    expect(getState().pages.get(1).location).toEqual('https://moz.org/1');
+    expect(getState().currentPageIndex).toEqual(1,
+      'CLOSE_TAB does not update selected tab if the tab destroyed was not selected.');
+  });
+
+  it('Should destroy a selected tab and select next when it is not last tab', function() {
+    const { getState, dispatch } = this.store;
+
+    dispatch(actions.setCurrentTab(1));
+    dispatch(actions.closeTab(1));
+
+    expect(getState().pages.size).toEqual(3);
+    expect(getState().pages.get(1).location).toEqual('https://moz.org/2');
+    expect(getState().currentPageIndex).toEqual(1,
+      'CLOSE_TAB on selected tab selects the next tab');
+  });
+
+  it('Should destroy a selected tab and select previous when it is the last tab', function() {
+    const { getState, dispatch } = this.store;
+
+    dispatch(actions.closeTab(3));
+    expect(getState().pages.size).toEqual(3);
+    expect(getState().pages.get(2).location).toEqual('https://moz.org/2');
+    expect(getState().currentPageIndex).toEqual(2,
+      'CLOSE_TAB on last selected tab selects the previous tab');
+  });
+
+  it('Destroying the last tab should reset state', function() {
+    const { getState, dispatch } = this.store;
+    dispatch(actions.closeTab(3));
+    dispatch(actions.closeTab(2));
+    dispatch(actions.closeTab(1));
+    expect(getState().currentPageIndex).toEqual(0);
+    expect(getState().pages.size).toEqual(1);
+
+    dispatch(actions.closeTab(0));
+    expect(getState().currentPageIndex).toEqual(0);
+    expect(getState().pages.size).toEqual(1);
+    expect(getState().pages.get(0).location).toEqual('https://www.mozilla.org/');
+  });
+});

--- a/test/ui/browser/actions/test-create-tab.js
+++ b/test/ui/browser/actions/test-create-tab.js
@@ -1,0 +1,38 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+import expect from 'expect';
+import configureStore from '../../../../ui/browser/store/store';
+import * as actions from '../../../../ui/browser/actions/main-actions';
+
+const HOME_PAGE = 'https://www.mozilla.org/';
+
+describe('Action - CREATE_TAB', () => {
+  beforeEach(function() {
+    this.store = configureStore();
+  });
+
+  it('Should create a new tab with default location and select it', function() {
+    const { getState, dispatch } = this.store;
+    expect(getState().currentPageIndex).toEqual(0);
+
+    dispatch(actions.createTab());
+    expect(getState().pages.size).toEqual(2);
+    expect(getState().pages.get(1).location).toEqual(HOME_PAGE,
+      'CREATE_TAB defaults to home page when no location given.');
+    expect(getState().currentPageIndex).toEqual(1,
+      'CREATE_TAB updates `currentPageIndex` when creating a new tab');
+  });
+
+  it('Should create a new tab with given location and select it', function() {
+    const { getState, dispatch } = this.store;
+    dispatch(actions.createTab());
+    dispatch(actions.createTab('https://github.com/'));
+
+    expect(getState().pages.size).toEqual(3);
+    expect(getState().pages.get(2).location).toEqual('https://github.com/',
+      'CREATE_TAB uses passed in location for new tab');
+    expect(getState().currentPageIndex).toEqual(2,
+      'CREATE_TAB updates `currentPageIndex` when creating a new tab with location');
+  });
+});

--- a/test/ui/browser/actions/test-default.js
+++ b/test/ui/browser/actions/test-default.js
@@ -1,0 +1,19 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+import expect from 'expect';
+import configureStore from '../../../../ui/browser/store/store';
+
+describe('Action - Default', () => {
+  beforeEach(function() {
+    this.store = configureStore();
+  });
+
+  it('Should have expected default state', function() {
+    const state = this.store.getState();
+    expect(state.currentPageIndex).toEqual(0);
+    expect(state.pageAreaVisible).toEqual(false);
+    expect(state.pages.size).toEqual(1);
+    expect(state.pages.get(0).location).toEqual('https://www.mozilla.org/');
+  });
+});

--- a/test/ui/browser/actions/test-duplicate-tab.js
+++ b/test/ui/browser/actions/test-duplicate-tab.js
@@ -1,0 +1,28 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+import expect from 'expect';
+import configureStore from '../../../../ui/browser/store/store';
+import * as actions from '../../../../ui/browser/actions/main-actions';
+
+describe('Action - DUPLICATE_TAB', () => {
+  beforeEach(function() {
+    this.store = configureStore();
+  });
+
+  it('Should create a new tab with source\'s location and select it', function() {
+    const { getState, dispatch } = this.store;
+    expect(getState().currentPageIndex).toEqual(0);
+
+    dispatch(actions.createTab('https://moz.org/1'));
+    dispatch(actions.createTab('https://moz.org/2'));
+    dispatch(actions.createTab('https://moz.org/3'));
+
+    dispatch(actions.duplicateTab(1));
+    expect(getState().pages.size).toEqual(5);
+    expect(getState().pages.get(4).location).toEqual('https://moz.org/1',
+      'DUPLICATE_TAB creates an appends a new tab with source\'s location');
+    expect(getState().currentPageIndex).toEqual(4,
+      'DUPLICATE_TAB updates `currentPageIndex` with new duplicated tab');
+  });
+});

--- a/test/ui/browser/actions/test-set-current-tab.js
+++ b/test/ui/browser/actions/test-set-current-tab.js
@@ -1,0 +1,25 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+import expect from 'expect';
+import configureStore from '../../../../ui/browser/store/store';
+import * as actions from '../../../../ui/browser/actions/main-actions';
+
+describe('Action - SET_CURRENT_TAB', () => {
+  beforeEach(function() {
+    this.store = configureStore();
+  });
+
+  it('Should update the current tab', function() {
+    const { getState, dispatch } = this.store;
+
+    dispatch(actions.createTab('http://moz.com'));
+    expect(getState().pages.size).toEqual(2);
+
+    expect(getState().currentPageIndex).toEqual(1);
+    dispatch(actions.setCurrentTab(0));
+    expect(getState().currentPageIndex).toEqual(0);
+    dispatch(actions.setCurrentTab(1));
+    expect(getState().currentPageIndex).toEqual(1);
+  });
+});

--- a/test/ui/browser/actions/test-set-location.js
+++ b/test/ui/browser/actions/test-set-location.js
@@ -1,0 +1,14 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+import expect from 'expect'; // eslint-disable-line
+import configureStore from '../../../../ui/browser/store/store';
+import * as actions from '../../../../ui/browser/actions/main-actions'; // eslint-disable-line
+
+describe('Action - SET_LOCATION', () => {
+  beforeEach(function() {
+    this.store = configureStore();
+  });
+
+  it('Should set location');
+});

--- a/test/ui/browser/actions/test-set-page-area-visibility.js
+++ b/test/ui/browser/actions/test-set-page-area-visibility.js
@@ -1,0 +1,29 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+import expect from 'expect';
+import configureStore from '../../../../ui/browser/store/store';
+import * as actions from '../../../../ui/browser/actions/main-actions';
+
+describe('Action - SET_PAGE_AREA_VISIBILITY', () => {
+  beforeEach(function() {
+    this.store = configureStore();
+  });
+
+  it('Should set pageAreaVisible', function() {
+    const { getState, dispatch } = this.store;
+
+    dispatch(actions.setPageAreaVisibility(true));
+    expect(getState().pageAreaVisible).toEqual(true);
+    dispatch(actions.setPageAreaVisibility(true));
+    expect(getState().pageAreaVisible).toEqual(true);
+
+    dispatch(actions.setPageAreaVisibility(false));
+    expect(getState().pageAreaVisible).toEqual(false);
+    dispatch(actions.setPageAreaVisibility(false));
+    expect(getState().pageAreaVisible).toEqual(false);
+
+    dispatch(actions.setPageAreaVisibility(true));
+    expect(getState().pageAreaVisible).toEqual(true);
+  });
+});

--- a/test/ui/browser/actions/test-set-page-details.js
+++ b/test/ui/browser/actions/test-set-page-details.js
@@ -1,0 +1,14 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+import expect from 'expect'; // eslint-disable-line
+import configureStore from '../../../../ui/browser/store/store';
+import * as actions from '../../../../ui/browser/actions/main-actions'; // eslint-disable-line
+
+describe('Action - SET_PAGE_DETAILS', () => {
+  beforeEach(function() {
+    this.store = configureStore();
+  });
+
+  it('Should set page details');
+});

--- a/test/ui/browser/actions/test-set-page-order.js
+++ b/test/ui/browser/actions/test-set-page-order.js
@@ -1,0 +1,14 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+import expect from 'expect'; // eslint-disable-line
+import configureStore from '../../../../ui/browser/store/store';
+import * as actions from '../../../../ui/browser/actions/main-actions'; // eslint-disable-line
+
+describe('Action - SET_PAGE_ORDER', () => {
+  beforeEach(function() {
+    this.store = configureStore();
+  });
+
+  it('Should set page order');
+});

--- a/ui/browser/reducers/main-reducers.js
+++ b/ui/browser/reducers/main-reducers.js
@@ -82,8 +82,10 @@ function attachTab(state, page) {
 }
 
 function closeTab(state, pageIndex) {
+  const pageCount = state.pages.size;
+
   // last tab, full reset
-  if (state.pages.size === 1) {
+  if (pageCount === 1) {
     return initialState;
   }
 
@@ -92,14 +94,11 @@ function closeTab(state, pageIndex) {
 
   const pages = state.pages.delete(pageIndex);
 
-  if (currentPageIndex === pageIndex) {
-    // If this was the selected page then select the one earlier in page order
-    currentPageIndex = pageIndex > 0 ? pageIndex - 1 : pageIndex;
-  } else {
-    // Otherwise update to the new index
-    if (currentPageIndex > pageIndex) {
-      currentPageIndex--;
-    }
+  // If tab closed comes before our current tab, or if this is the right-most
+  // tab and it's selected, decrement the current page index
+  if (currentPageIndex > pageIndex ||
+       (currentPageIndex === pageIndex && pageIndex === (pageCount - 1))) {
+    currentPageIndex--;
   }
 
   return state.set('pages', pages)

--- a/ui/browser/reducers/main-reducers.js
+++ b/ui/browser/reducers/main-reducers.js
@@ -67,7 +67,7 @@ function createTab(state, location = HOME_PAGE) {
 }
 
 function duplicateTab(state, pageIndex) {
-  const location = state.pages.get(pageIndex);
+  const location = state.pages.get(pageIndex).location;
   const page = new Page({ location });
   return state.update('pages', pages => pages.push(page))
               .set('currentPageIndex', state.pages.size);

--- a/ui/browser/views/app.jsx
+++ b/ui/browser/views/app.jsx
@@ -18,7 +18,6 @@ import BrowserWindow from './browser.jsx';
 export const App = function({ state, dispatch }) {
   return (
     <BrowserWindow pages={state.pages}
-      pageOrder={state.pageOrder}
       currentPageIndex={state.currentPageIndex}
       pageAreaVisible={state.pageAreaVisible}
       ipcRenderer={ipcRenderer}

--- a/ui/browser/views/browser.jsx
+++ b/ui/browser/views/browser.jsx
@@ -41,7 +41,7 @@ class BrowserWindow extends Component {
   }
 
   render() {
-    const { dispatch, pages, currentPageIndex, pageOrder, ipcRenderer,
+    const { dispatch, pages, currentPageIndex, ipcRenderer,
             pageAreaVisible } = this.props;
     const navBack = e => getCurrentWebView(e.target.ownerDocument).goBack();
     const navForward = e => getCurrentWebView(e.target.ownerDocument).goForward();
@@ -62,7 +62,7 @@ class BrowserWindow extends Component {
             close, openMenu, onLocationChange, onLocationContextMenu,
             onLocationReset, bookmark, unbookmark, pageAreaVisible, ipcRenderer,
             setPageAreaVisibility }} />
-        <TabBar {...{ pages, pageOrder, currentPageIndex, pageAreaVisible, dispatch }} />
+        <TabBar {...{ pages, currentPageIndex, pageAreaVisible, dispatch }} />
         <div id="content-area">
           {pages.map((page, pageIndex) => (
             <Page key={`page-${pageIndex}`}
@@ -79,7 +79,6 @@ class BrowserWindow extends Component {
 }
 
 BrowserWindow.propTypes = {
-  pageOrder: PropTypes.object.isRequired,
   pages: PropTypes.object.isRequired,
   currentPageIndex: PropTypes.number.isRequired,
   dispatch: PropTypes.func.isRequired,

--- a/ui/browser/views/tabbar/tabbar.jsx
+++ b/ui/browser/views/tabbar/tabbar.jsx
@@ -14,14 +14,17 @@ import React, { PropTypes } from 'react';
 import Tab from './tab.jsx';
 import { menuTabContext } from '../../actions/external';
 import { createTab, closeTab, setCurrentTab } from '../../actions/main-actions';
-import { TabBarDragDrop, TabDragDrop } from './dragdrop';
+
+// TODO Fix up dragDrop
+// import { TabBarDragDrop, TabDragDrop } from './dragdrop';
 
 /**
  * The TabBar runs across the top of each browser window, containing the
  * window management buttons, and browser tabs
  */
-const TabBar = ({ pageOrder, pages, currentPageIndex, dispatch, pageAreaVisible }) => {
-  const barDragDrop = new TabBarDragDrop(pages, pageOrder, dispatch);
+const TabBar = ({ pages, currentPageIndex, dispatch, pageAreaVisible }) => {
+  // TODO Fix up dragDrop
+  const barDragDrop = { handlers: {} }; // new TabBarDragDrop(pages, dispatch);
 
   // This is the 'pages' section, which can be collapsed
   if (!pageAreaVisible) {
@@ -33,9 +36,9 @@ const TabBar = ({ pageOrder, pages, currentPageIndex, dispatch, pageAreaVisible 
       dragzone="copy string:test/uri-list"
       {...barDragDrop.handlers}>
 
-      {pageOrder.map((i) => {
-        const page = pages.get(i);
-        const dragDrop = new TabDragDrop(page, pageOrder, i);
+      {pages.map((page, i) => {
+        // TODO Fix up dragDrop
+        const dragDrop = { handlers: {} }; // new TabDragDrop(page, pages, i);
 
         return (
           <Tab key={`browser-tab-${i}`}
@@ -62,7 +65,6 @@ const TabBar = ({ pageOrder, pages, currentPageIndex, dispatch, pageAreaVisible 
 };
 
 TabBar.propTypes = {
-  pageOrder: PropTypes.object.isRequired,
   pages: PropTypes.object.isRequired,
   currentPageIndex: PropTypes.number.isRequired,
   dispatch: PropTypes.func.isRequired,

--- a/ui/shared/instrument.js
+++ b/ui/shared/instrument.js
@@ -8,7 +8,14 @@
  * @module instrument
  */
 
-import { ipcRenderer } from 'electron';
+// Stub out ipcRenderer when electron cannot be found (unit tests)
+const ipcRenderer = (function() {
+  try {
+    return require('electron').ipcRenderer;
+  } catch (e) {
+    return { send() {} };
+  }
+}());
 
 /**
  * Send an instrumentation event to Google Analytics.


### PR DESCRIPTION
Tests for action creators mostly, also removing `pageOrder` state. This completely disables the tab dragdrop, but it already wasn't working and we're not sure what that UX will even be.

Next steps are cleaning up the actions and make enforce the action flow (tracked in other issues)