### PR TITLE
Don't log actions when testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "node build/main.js --run",
     "dev": "node build/main.js --run-dev",
     "package": "node build/main.js --package",
-    "test": "mocha",
+    "test": "NODE_ENV=test mocha",
     "postinstall": "electron-rebuild"
   },
   "license": "Apache-2.0",

--- a/ui/browser/store/store.js
+++ b/ui/browser/store/store.js
@@ -22,14 +22,23 @@ const instrumenter = store => next => action => { // eslint-disable-line no-unus
   return next(action);
 };
 
-export default function configureStore() {
-  const logger = createLogger({
-    duration: true,
-    collapsed: true,
-    stateTransformer(state) { return state.toJS(); },
-  });
+const logger = createLogger({
+  duration: true,
+  collapsed: true,
+  stateTransformer(state) { return state.toJS(); },
+});
 
-  const store = createStore(rootReducer, applyMiddleware(logger, instrumenter));
+export default function configureStore() {
+  const middlewares = [instrumenter];
+
+  // NODE_ENV is only set when testing, as it runs in a node environment,
+  // rather than a webpacked one where we do not use NODE_ENV. Don't use
+  // logging middleware in tests.
+  if (process.env.NODE_ENV !== 'test') {
+    middlewares.unshift(logger);
+  }
+
+  const store = createStore(rootReducer, applyMiddleware(...middlewares));
 
   if (module.hot) {
     // Enable Webpack hot module replacement for reducers. We need to use


### PR DESCRIPTION
Since adding Redux action tests, we get a lot of console spam when running tests. This doesn't do anything if you're just using `mocha` on the CLI, but should always use npm scripts anyway.

Nick, I think you added some middleware, r?ing you