### PR TITLE
Cache node_modules between builds, package builds and do proper 64-bit builds on windows.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ osx_image: xcode7.2
 sudo: required
 dist: trusty
 
+cache:
+  directories:
+    - node_modules
+
 before_install: scripts/bootstrap.py
 install:
   - nvm --version
@@ -16,6 +20,9 @@ install:
 
 script:
   - npm test
+
+after_success:
+  - npm run package
 
 branches:
   only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,5 @@
 platform: x64
+image: Visual Studio 2013
 
 environment:
   nodejs_version: "5.9"
@@ -7,13 +8,22 @@ branches:
   only:
     - master
 
+pull_requests:
+  do_not_increment_build_number: true
+
+cache:
+  - node_modules
+  - '%APPDATA%\npm-cache'
+
 install:
-  - ps: Install-Product node $env:nodejs_version
+  - ps: Install-Product node $env:nodejs_version $env:PLATFORM
   - node --version
   - npm --version
+  - set npm_config_arch=%PLATFORM%
   - npm install --progress false --depth 0
 
 build: off
 
-after_test:
+test_script:
   - npm test
+  - npm run package


### PR DESCRIPTION
A few updates to the CI config ready for making builds available.

Signed-off-by: Dave Townsend <dtownsend@oxymoronical.com>