### PR TITLE
Navigation commands for WebView should be handled by Redux actions vi…

### DIFF
--- a/test/ui/browser/actions/test-navigate-page-back.js
+++ b/test/ui/browser/actions/test-navigate-page-back.js
@@ -1,0 +1,63 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+import expect from 'expect';
+import configureStore from '../../../../ui/browser/store/store';
+import * as actions from '../../../../ui/browser/actions/main-actions';
+
+describe('Action - NAVIGATE_PAGE_BACK', () => {
+  beforeEach(function() {
+    this.store = configureStore();
+    this.getState = () => this.store.getState().browserWindow;
+    this.dispatch = this.store.dispatch;
+    const { dispatch } = this;
+    dispatch(actions.createTab('http://moz1.org'));
+    dispatch(actions.createTab('http://moz2.org'));
+    dispatch(actions.createTab('http://moz3.org'));
+    dispatch(actions.closeTab(0));
+  });
+
+  it('Should execute navigate back commands in page', function() {
+    const { dispatch, getState } = this;
+
+    // Ensure page can go back
+    dispatch(actions.setPageDetails(1, { canGoBack: true }));
+
+    dispatch(actions.navigatePageBack(1));
+    expect(getState().pages.get(1).commands.size).toEqual(1);
+    expect(getState().pages.get(1).commands.get(0).command).toEqual('back');
+
+    dispatch(actions.navigatePageBack(1));
+    expect(getState().pages.get(1).commands.size).toEqual(2);
+    expect(getState().pages.get(1).commands.get(1).command).toEqual('back');
+  });
+
+  it('Should execute navigate back commands in current page if -1 specified', function() {
+    const { dispatch, getState } = this;
+
+    // Ensure page can go back
+    dispatch(actions.setPageDetails(2, { canGoBack: true }));
+
+    dispatch(actions.navigatePageBack(-1));
+    expect(getState().currentPageIndex).toEqual(2);
+    expect(getState().pages.get(2).commands.size).toEqual(1);
+    expect(getState().pages.get(2).commands.get(0).command).toEqual('back');
+  });
+
+  it('Should throw if page cannot go back', function() {
+    const { dispatch, getState } = this;
+
+    // Ensure page cannot go back
+    dispatch(actions.setPageDetails(1, { canGoBack: false }));
+
+    try {
+      dispatch(actions.navigatePageBack(1));
+      expect(false).toEqual(true,
+        'Expected NAVIGATE_PAGE_BACK to throw when page cannot go back.');
+    } catch (e) {
+      expect(true).toEqual(true,
+        'Expected NAVIGATE_PAGE_BACK to throw when page cannot go back.');
+    }
+    expect(getState().pages.get(2).commands.size).toEqual(0);
+  });
+});

--- a/test/ui/browser/actions/test-navigate-page-forward.js
+++ b/test/ui/browser/actions/test-navigate-page-forward.js
@@ -1,0 +1,62 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+import expect from 'expect';
+import configureStore from '../../../../ui/browser/store/store';
+import * as actions from '../../../../ui/browser/actions/main-actions';
+
+describe('Action - NAVIGATE_PAGE_FORWARD', () => {
+  beforeEach(function() {
+    this.store = configureStore();
+    this.getState = () => this.store.getState().browserWindow;
+    this.dispatch = this.store.dispatch;
+    const { dispatch } = this;
+    dispatch(actions.createTab('http://moz1.org'));
+    dispatch(actions.createTab('http://moz2.org'));
+    dispatch(actions.createTab('http://moz3.org'));
+    dispatch(actions.closeTab(0));
+  });
+
+  it('Should execute navigate forward commands in page', function() {
+    const { dispatch, getState } = this;
+
+    // Ensure page can go forward
+    dispatch(actions.setPageDetails(1, { canGoForward: true }));
+
+    dispatch(actions.navigatePageForward(1));
+    expect(getState().pages.get(1).commands.size).toEqual(1);
+    expect(getState().pages.get(1).commands.get(0).command).toEqual('forward');
+
+    dispatch(actions.navigatePageForward(1));
+    expect(getState().pages.get(1).commands.size).toEqual(2);
+    expect(getState().pages.get(1).commands.get(1).command).toEqual('forward');
+  });
+
+  it('Should execute navigate forward commands in current page if -1 specified', function() {
+    const { dispatch, getState } = this;
+
+    // Ensure page can go forward
+    dispatch(actions.setPageDetails(2, { canGoForward: true }));
+
+    dispatch(actions.navigatePageForward(-1));
+    expect(getState().currentPageIndex).toEqual(2);
+    expect(getState().pages.get(2).commands.get(0).command).toEqual('forward');
+  });
+
+  it('Should throw if page cannot go forward', function() {
+    const { dispatch, getState } = this;
+
+    // Ensure page cannot go forward
+    dispatch(actions.setPageDetails(1, { canGoForward: false }));
+
+    try {
+      dispatch(actions.navigatePageForward(1));
+      expect(false).toEqual(true,
+        'Expected NAVIGATE_PAGE_FORWARD to throw when page cannot go forward.');
+    } catch (e) {
+      expect(true).toEqual(true,
+        'Expected NAVIGATE_PAGE_FORWARD to throw when page cannot go forward.');
+    }
+    expect(getState().pages.get(2).commands.size).toEqual(0);
+  });
+});

--- a/test/ui/browser/actions/test-navigate-page-refresh.js
+++ b/test/ui/browser/actions/test-navigate-page-refresh.js
@@ -1,0 +1,63 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+import expect from 'expect';
+import configureStore from '../../../../ui/browser/store/store';
+import * as actions from '../../../../ui/browser/actions/main-actions';
+
+describe('Action - NAVIGATE_PAGE_REFRESH', () => {
+  beforeEach(function() {
+    this.store = configureStore();
+    this.getState = () => this.store.getState().browserWindow;
+    this.dispatch = this.store.dispatch;
+    const { dispatch } = this;
+    dispatch(actions.createTab('http://moz1.org'));
+    dispatch(actions.createTab('http://moz2.org'));
+    dispatch(actions.createTab('http://moz3.org'));
+    dispatch(actions.closeTab(0));
+  });
+
+  it('Should execute navigate refresh commands in page', function() {
+    const { dispatch, getState } = this;
+
+    // Ensure page can refresh
+    dispatch(actions.setPageDetails(1, { canRefresh: true }));
+
+    dispatch(actions.navigatePageRefresh(1));
+    expect(getState().pages.get(1).commands.size).toEqual(1);
+    expect(getState().pages.get(1).commands.get(0).command).toEqual('refresh');
+
+    dispatch(actions.navigatePageRefresh(1));
+    expect(getState().pages.get(1).commands.size).toEqual(2);
+    expect(getState().pages.get(1).commands.get(1).command).toEqual('refresh');
+  });
+
+  it('Should execute navigate refresh commands in current page if -1 specified', function() {
+    const { dispatch, getState } = this;
+
+    // Ensure page can refresh
+    dispatch(actions.setPageDetails(2, { canRefresh: true }));
+
+    dispatch(actions.navigatePageRefresh(-1));
+    expect(getState().currentPageIndex).toEqual(2);
+    expect(getState().pages.get(2).commands.size).toEqual(1);
+    expect(getState().pages.get(2).commands.get(0).command).toEqual('refresh');
+  });
+
+  it('Should throw if page cannot refresh', function() {
+    const { dispatch, getState } = this;
+
+    // Ensure page cannot refresh
+    dispatch(actions.setPageDetails(1, { canRefresh: false }));
+
+    try {
+      dispatch(actions.navigatePageRefresh(1));
+      expect(false).toEqual(true,
+        'Expected NAVIGATE_PAGE_REFRESH to throw when page cannot refresh.');
+    } catch (e) {
+      expect(true).toEqual(true,
+        'Expected NAVIGATE_PAGE_REFRESH to throw when page cannot refresh.');
+    }
+    expect(getState().pages.get(1).commands.size).toEqual(0);
+  });
+});

--- a/test/ui/browser/actions/test-navigate-page-to.js
+++ b/test/ui/browser/actions/test-navigate-page-to.js
@@ -1,0 +1,46 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+import expect from 'expect';
+import configureStore from '../../../../ui/browser/store/store';
+import * as actions from '../../../../ui/browser/actions/main-actions';
+
+const RUST_URL = 'http://rust-lang.org';
+
+describe('Action - NAVIGATE_PAGE_TO', () => {
+  beforeEach(function() {
+    this.store = configureStore();
+    this.getState = () => this.store.getState().browserWindow;
+    this.dispatch = this.store.dispatch;
+    const { dispatch } = this;
+    dispatch(actions.createTab('http://moz1.org'));
+    dispatch(actions.createTab('http://moz2.org'));
+    dispatch(actions.createTab('http://moz3.org'));
+    dispatch(actions.closeTab(0));
+  });
+
+  it('Should execute navigate commands in page', function() {
+    const { dispatch, getState } = this;
+
+    dispatch(actions.navigatePageTo(1, RUST_URL));
+
+    expect(getState().pages.get(1).commands.size).toEqual(1);
+    expect(getState().pages.get(1).commands.get(0).command).toEqual('navigate-to');
+    expect(getState().pages.get(1).commands.get(0).location).toEqual(RUST_URL);
+
+    dispatch(actions.navigatePageTo(1, `${RUST_URL}/documentation.html`));
+    expect(getState().pages.get(1).commands.size).toEqual(2);
+    expect(getState().pages.get(1).commands.get(1).command).toEqual('navigate-to');
+    expect(getState().pages.get(1).commands.get(1).location).toEqual(
+      `${RUST_URL}/documentation.html`);
+  });
+
+  it('Should execute navigate commands in current page if -1 specified', function() {
+    const { dispatch, getState } = this;
+
+    dispatch(actions.navigatePageTo(-1, RUST_URL));
+    expect(getState().currentPageIndex).toEqual(2);
+    expect(getState().pages.get(2).commands.get(0).command).toEqual('navigate-to');
+    expect(getState().pages.get(2).commands.get(0).location).toEqual(RUST_URL);
+  });
+});

--- a/test/ui/browser/views/navbar/test-navbar.js
+++ b/test/ui/browser/views/navbar/test-navbar.js
@@ -28,6 +28,7 @@ function createSpyProps() {
     onLocationContextMenu: expect.createSpy(),
     onLocationReset: expect.createSpy(),
     setPageAreaVisibility: expect.createSpy(),
+    navigateTo: expect.createSpy(),
   };
 }
 

--- a/ui/browser/actions/external.js
+++ b/ui/browser/actions/external.js
@@ -10,7 +10,9 @@ CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 */
 
-import { createTab, setPageDetails, duplicateTab, closeTab } from './main-actions';
+import {
+  createTab, setPageDetails, duplicateTab, closeTab, navigatePageTo,
+} from './main-actions';
 import { getCurrentWebView, fixURL } from '../browser-util';
 import { remote, clipboard, ipcRenderer } from 'electron';
 
@@ -84,14 +86,12 @@ export function menuLocationContext(input, dispatch) {
 
   menu.append(new MenuItem({
     label: 'Paste and Go',
-    click: ev => {
+    click: () => {
       const before = input.value.slice(0, input.selectionStart);
       const after = input.value.slice(input.selectionEnd);
       const loc = before + clipboard.readText() + after;
       dispatch(setPageDetails(-1, { userTyped: loc }));
-
-      const webview = getCurrentWebView(ev.target.ownerDocument);
-      webview.setAttribute('src', fixURL(loc));
+      dispatch(navigatePageTo(-1, fixURL(loc)));
     },
   }));
 

--- a/ui/browser/actions/main-actions.js
+++ b/ui/browser/actions/main-actions.js
@@ -50,3 +50,19 @@ export function bookmark(url, title) {
 export function unbookmark(url) {
   return { type: types.SET_BOOKMARK_STATE, url, isBookmarked: false };
 }
+
+export function navigatePageTo(pageIndex, location) {
+  return { type: types.NAVIGATE_PAGE_TO, pageIndex, location };
+}
+
+export function navigatePageBack(pageIndex) {
+  return { type: types.NAVIGATE_PAGE_BACK, pageIndex };
+}
+
+export function navigatePageForward(pageIndex) {
+  return { type: types.NAVIGATE_PAGE_FORWARD, pageIndex };
+}
+
+export function navigatePageRefresh(pageIndex) {
+  return { type: types.NAVIGATE_PAGE_REFRESH, pageIndex };
+}

--- a/ui/browser/browser-util.js
+++ b/ui/browser/browser-util.js
@@ -71,3 +71,13 @@ export function getWebView(document, pageIndex) {
   }
   return element.webview;
 }
+
+/**
+ * Takes an object and attaches a unique `id` to it.
+ *
+ * @TODO Should we start using UUIDs?
+ */
+let ATTACH_UNIQUE_ID = 0;
+export function attachUnique(obj) {
+  return Object.assign(obj, { id: ATTACH_UNIQUE_ID++ });
+}

--- a/ui/browser/constants/action-types.js
+++ b/ui/browser/constants/action-types.js
@@ -10,12 +10,16 @@ CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 */
 
-export const CREATE_TAB = 'CREATE_TAB';
-export const DUPLICATE_TAB = 'DUPLICATE_TAB';
 export const ATTACH_TAB = 'ATTACH_TAB';
 export const CLOSE_TAB = 'CLOSE_TAB';
-export const SET_PAGE_DETAILS = 'SET_PAGE_DETAILS';
+export const CREATE_TAB = 'CREATE_TAB';
+export const DUPLICATE_TAB = 'DUPLICATE_TAB';
+export const NAVIGATE_PAGE_BACK = 'NAVIGATE_PAGE_BACK';
+export const NAVIGATE_PAGE_FORWARD = 'NAVIGATE_PAGE_FORWARD';
+export const NAVIGATE_PAGE_REFRESH = 'NAVIGATE_PAGE_REFRESH';
+export const NAVIGATE_PAGE_TO = 'NAVIGATE_PAGE_TO';
 export const SET_CURRENT_TAB = 'SET_CURRENT_TAB';
-export const SET_PAGE_ORDER = 'SET_PAGE_ORDER';
 export const SET_PAGE_AREA_VISIBILITY = 'SET_PAGE_AREA_VISIBILITY';
 export const SET_BOOKMARK_STATE = 'SET_BOOKMARK_STATE';
+export const SET_PAGE_DETAILS = 'SET_PAGE_DETAILS';
+export const SET_PAGE_ORDER = 'SET_PAGE_ORDER';

--- a/ui/browser/model/index.js
+++ b/ui/browser/model/index.js
@@ -49,5 +49,5 @@ export const Page = Immutable.Record({
   canGoBack: false,
   canGoForward: false,
   canRefresh: false,
-  executeCommand: undefined,
+  commands: Immutable.List(),
 });

--- a/ui/browser/model/index.js
+++ b/ui/browser/model/index.js
@@ -49,4 +49,5 @@ export const Page = Immutable.Record({
   canGoBack: false,
   canGoForward: false,
   canRefresh: false,
+  executeCommand: undefined,
 });

--- a/ui/browser/reducers/main-reducers.js
+++ b/ui/browser/reducers/main-reducers.js
@@ -133,9 +133,11 @@ function navigatePageBack(state, pageIndex) {
     pageIndex = state.currentPageIndex;
   }
 
-  return state.setIn(['pages', pageIndex, 'executeCommand'], attachUnique({
+  assert(state.pages.get(pageIndex).canGoBack, 'Page cannot go back.');
+
+  return state.updateIn(['pages', pageIndex, 'commands'], commands => commands.push(attachUnique({
     command: 'back',
-  }));
+  })));
 }
 
 function navigatePageForward(state, pageIndex) {
@@ -146,9 +148,11 @@ function navigatePageForward(state, pageIndex) {
     pageIndex = state.currentPageIndex;
   }
 
-  return state.setIn(['pages', pageIndex, 'executeCommand'], attachUnique({
+  assert(state.pages.get(pageIndex).canGoForward, 'Page cannot go forward.');
+
+  return state.updateIn(['pages', pageIndex, 'commands'], commands => commands.push(attachUnique({
     command: 'forward',
-  }));
+  })));
 }
 
 function navigatePageRefresh(state, pageIndex) {
@@ -159,9 +163,11 @@ function navigatePageRefresh(state, pageIndex) {
     pageIndex = state.currentPageIndex;
   }
 
-  return state.setIn(['pages', pageIndex, 'executeCommand'], attachUnique({
+  assert(state.pages.get(pageIndex).canRefresh, 'Page cannot refresh.');
+
+  return state.updateIn(['pages', pageIndex, 'commands'], commands => commands.push(attachUnique({
     command: 'refresh',
-  }));
+  })));
 }
 
 function navigatePageTo(state, pageIndex, location) {
@@ -174,10 +180,10 @@ function navigatePageTo(state, pageIndex, location) {
     pageIndex = state.currentPageIndex;
   }
 
-  return state.setIn(['pages', pageIndex, 'executeCommand'], attachUnique({
+  return state.updateIn(['pages', pageIndex, 'commands'], commands => commands.push(attachUnique({
     location,
     command: 'navigate-to',
-  }));
+  })));
 }
 
 function setPageDetails(state, pageIndex, details) {

--- a/ui/browser/reducers/main-reducers.js
+++ b/ui/browser/reducers/main-reducers.js
@@ -16,6 +16,7 @@ import Immutable from 'immutable';
 import * as types from '../constants/action-types';
 import { State, Page } from '../model';
 import * as profileDiffTypes from '../../../app/shared/constants/profile-diff-types';
+import { attachUnique } from '../browser-util';
 
 /**
  * Fairly sure we should hard code this
@@ -41,6 +42,18 @@ export default function basic(state = initialState, action) {
 
     case types.CLOSE_TAB:
       return closeTab(state, action.pageIndex);
+
+    case types.NAVIGATE_PAGE_BACK:
+      return navigatePageBack(state, action.pageIndex);
+
+    case types.NAVIGATE_PAGE_FORWARD:
+      return navigatePageForward(state, action.pageIndex);
+
+    case types.NAVIGATE_PAGE_REFRESH:
+      return navigatePageRefresh(state, action.pageIndex);
+
+    case types.NAVIGATE_PAGE_TO:
+      return navigatePageTo(state, action.pageIndex, action.location);
 
     case types.SET_PAGE_DETAILS:
       return setPageDetails(state, action.pageIndex, action.details);
@@ -110,6 +123,61 @@ function closeTab(state, pageIndex) {
 
   return state.set('pages', pages)
               .set('currentPageIndex', currentPageIndex);
+}
+
+function navigatePageBack(state, pageIndex) {
+  assert(typeof pageIndex === 'number',
+    '`pageIndex` must be a number.');
+
+  if (pageIndex === -1) {
+    pageIndex = state.currentPageIndex;
+  }
+
+  return state.setIn(['pages', pageIndex, 'executeCommand'], attachUnique({
+    command: 'back',
+  }));
+}
+
+function navigatePageForward(state, pageIndex) {
+  assert(typeof pageIndex === 'number',
+    '`pageIndex` must be a number.');
+
+  if (pageIndex === -1) {
+    pageIndex = state.currentPageIndex;
+  }
+
+  return state.setIn(['pages', pageIndex, 'executeCommand'], attachUnique({
+    command: 'forward',
+  }));
+}
+
+function navigatePageRefresh(state, pageIndex) {
+  assert(typeof pageIndex === 'number',
+    '`pageIndex` must be a number.');
+
+  if (pageIndex === -1) {
+    pageIndex = state.currentPageIndex;
+  }
+
+  return state.setIn(['pages', pageIndex, 'executeCommand'], attachUnique({
+    command: 'refresh',
+  }));
+}
+
+function navigatePageTo(state, pageIndex, location) {
+  assert(typeof pageIndex === 'number',
+    '`pageIndex` must be a number.');
+  assert(typeof location === 'string',
+    '`location` must be a string.');
+
+  if (pageIndex === -1) {
+    pageIndex = state.currentPageIndex;
+  }
+
+  return state.setIn(['pages', pageIndex, 'executeCommand'], attachUnique({
+    location,
+    command: 'navigate-to',
+  }));
 }
 
 function setPageDetails(state, pageIndex, details) {

--- a/ui/browser/views/browser.jsx
+++ b/ui/browser/views/browser.jsx
@@ -24,12 +24,12 @@ import {
 import {
   setPageAreaVisibility as setPageAreaVisibilityAction,
   createTab, attachTab, closeTab, setPageDetails,
+  navigatePageBack, navigatePageForward, navigatePageRefresh, navigatePageTo,
 } from '../actions/main-actions';
 
 import * as mainActions from '../actions/main-actions';
 import * as profileCommands from '../../../app/shared/profile-commands';
 
-import { getCurrentWebView } from '../browser-util';
 import '../../shared/web-view';
 
 const BROWSER_WINDOW_STYLE = Style.registerStyle({
@@ -69,10 +69,9 @@ class BrowserWindow extends Component {
     const {
       ipcRenderer, dispatch, profile, pages, currentPageIndex, pageAreaVisible,
     } = this.props;
-
-    const navBack = e => getCurrentWebView(e.target.ownerDocument).goBack();
-    const navForward = e => getCurrentWebView(e.target.ownerDocument).goForward();
-    const navRefresh = e => getCurrentWebView(e.target.ownerDocument).reload();
+    const navBack = () => dispatch(navigatePageBack(-1));
+    const navForward = () => dispatch(navigatePageForward(-1));
+    const navRefresh = () => dispatch(navigatePageRefresh(-1));
     const openMenu = () => menuBrowser(dispatch);
     const isBookmarked = (url) => profile.bookmarks.has(url);
     const bookmark = (title, url) => {
@@ -91,6 +90,7 @@ class BrowserWindow extends Component {
     const onLocationContextMenu = e => menuLocationContext(e.target, dispatch);
     const onLocationReset = () => dispatch(setPageDetails(-1, { userTyped: void 0 }));
     const setPageAreaVisibility = (visible) => dispatch(setPageAreaVisibilityAction(visible));
+    const navigateTo = loc => dispatch(navigatePageTo(-1, loc));
 
     return (
       <div className={BROWSER_WINDOW_STYLE} >
@@ -98,7 +98,7 @@ class BrowserWindow extends Component {
           {...{ pages, navBack, navForward, navRefresh, minimize, maximize,
             close, openMenu, onLocationChange, onLocationContextMenu,
             onLocationReset, isBookmarked, bookmark, unbookmark, pageAreaVisible, ipcRenderer,
-            setPageAreaVisibility }} />
+            setPageAreaVisibility, navigateTo }} />
         <TabBar {...{ pages, currentPageIndex, pageAreaVisible, dispatch }} />
         <div className={CONTENT_AREA_STYLE}>
           {pages.map((page, pageIndex) => (
@@ -157,6 +157,6 @@ function attachIPCRendererListeners({ dispatch, currentPageIndex, ipcRenderer })
   });
 
   ipcRenderer.on('page-reload', () => {
-    getCurrentWebView(document).reload();
+    dispatch(navigatePageRefresh(-1));
   });
 }

--- a/ui/browser/views/navbar/location.jsx
+++ b/ui/browser/views/navbar/location.jsx
@@ -126,9 +126,7 @@ class Location extends Component {
 
   handleURLBarKeyDown(ev) {
     if (ev.keyCode === 13) { // enter
-      const location = fixURL(ev.target.value);
-      const webview = getCurrentWebView(ev.target.ownerDocument);
-      webview.setAttribute('src', location);
+      this.props.navigateTo(fixURL(ev.target.value));
     } else if (ev.keyCode === 27) { // esc
       this.props.onLocationReset();
       ev.target.select();
@@ -140,6 +138,31 @@ class Location extends Component {
     const urlValue = page.userTyped !== null ? page.userTyped : page.location;
     const { showURLBar } = this.state;
 
+<<<<<<< HEAD
+=======
+    const onBookmark = e => {
+      // TODO avoid Location reaching into the webview for this information
+      const webview = getCurrentWebView(e.target.ownerDocument);
+      const title = webview.getTitle();
+      const url = webview.getURL();
+      if (isBookmarked(url)) {
+        unbookmark(url);
+      } else {
+        bookmark(title, url);
+      }
+    };
+
+    const bookmarkImage = (() => {
+      if (page.isLoading) {
+        return 'glyph-bookmark-unknown-16.svg';
+      }
+      if (isBookmarked(page.location)) {
+        return 'glyph-bookmark-filled-16.svg';
+      }
+      return 'glyph-bookmark-hollow-16.svg';
+    })();
+
+>>>>>>> Navigation commands for WebView should be handled by Redux actions via state changes observed by Page. r=vp,linclark
     return (
       <div id="browser-location-bar"
         className={LOCATION_BAR_STYLE}>
@@ -187,6 +210,7 @@ Location.propTypes = {
   bookmark: PropTypes.func.isRequired,
   unbookmark: PropTypes.func.isRequired,
   ipcRenderer: PropTypes.object.isRequired,
+  navigateTo: PropTypes.func.isRequired,
 };
 
 export default Location;

--- a/ui/browser/views/navbar/location.jsx
+++ b/ui/browser/views/navbar/location.jsx
@@ -138,31 +138,6 @@ class Location extends Component {
     const urlValue = page.userTyped !== null ? page.userTyped : page.location;
     const { showURLBar } = this.state;
 
-<<<<<<< HEAD
-=======
-    const onBookmark = e => {
-      // TODO avoid Location reaching into the webview for this information
-      const webview = getCurrentWebView(e.target.ownerDocument);
-      const title = webview.getTitle();
-      const url = webview.getURL();
-      if (isBookmarked(url)) {
-        unbookmark(url);
-      } else {
-        bookmark(title, url);
-      }
-    };
-
-    const bookmarkImage = (() => {
-      if (page.isLoading) {
-        return 'glyph-bookmark-unknown-16.svg';
-      }
-      if (isBookmarked(page.location)) {
-        return 'glyph-bookmark-filled-16.svg';
-      }
-      return 'glyph-bookmark-hollow-16.svg';
-    })();
-
->>>>>>> Navigation commands for WebView should be handled by Redux actions via state changes observed by Page. r=vp,linclark
     return (
       <div id="browser-location-bar"
         className={LOCATION_BAR_STYLE}>

--- a/ui/browser/views/navbar/navbar.jsx
+++ b/ui/browser/views/navbar/navbar.jsx
@@ -53,6 +53,7 @@ function NavBar(props) {
     navBack, navForward, navRefresh, page, pages, openMenu, ipcRenderer,
     minimize, maximize, close, isBookmarked, bookmark, unbookmark, setPageAreaVisibility,
     onLocationChange, onLocationContextMenu, onLocationReset, pageAreaVisible,
+    navigateTo,
   } = props;
 
   if (page == null) {
@@ -102,7 +103,9 @@ function NavBar(props) {
         disabled={!page.canRefresh} />
       <Location {
         ...{ page, ipcRenderer, isBookmarked, bookmark, unbookmark,
-          onLocationChange, onLocationContextMenu, onLocationReset } } />
+          onLocationChange, onLocationContextMenu, onLocationReset,
+          navigateTo }
+      } />
       <Btn id="browser-navbar-minimize"
         className={NAVBAR_BUTTON_STYLE}
         title="Minimize"
@@ -143,6 +146,7 @@ NavBar.propTypes = {
   onLocationContextMenu: PropTypes.func.isRequired,
   onLocationReset: PropTypes.func.isRequired,
   setPageAreaVisibility: PropTypes.func.isRequired,
+  navigateTo: PropTypes.func.isRequired,
 };
 
 export default NavBar;

--- a/ui/browser/views/page/page.jsx
+++ b/ui/browser/views/page/page.jsx
@@ -33,6 +33,7 @@ const WEB_VIEW_INLINE_STYLE = {
 };
 
 class Page extends Component {
+
   componentDidMount() {
     const { page, pageIndex, dispatch, ipcRenderer } = this.props;
     const { webview } = this.refs.webviewWrapper;
@@ -41,6 +42,39 @@ class Page extends Component {
 
     if (!page.guestInstanceId && page.location) {
       webview.setAttribute('src', fixURL(page.location));
+    }
+  }
+
+  /**
+   * After Page receives new properties, check to see if the id
+   * of the latest command has changed and execute the command on WebView
+   */
+  componentDidUpdate({ page }) {
+    const currentPage = this.props.page;
+    const previousCommandId = page.executeCommand && page.executeCommand.id;
+    const currentCommandId = currentPage.executeCommand && currentPage.executeCommand.id;
+    if (previousCommandId !== currentCommandId) {
+      this.executeCommand(currentPage.executeCommand);
+    }
+  }
+
+  executeCommand(command) {
+    const { webview } = this.webview;
+    switch (command.command) {
+      case 'back':
+        webview.goBack();
+        break;
+      case 'forward':
+        webview.goForward();
+        break;
+      case 'refresh':
+        webview.reload();
+        break;
+      case 'navigate-to':
+        webview.setAttribute('src', command.location);
+        break;
+      default:
+        throw new Error(`Unknown command for WebView: ${command.command}`);
     }
   }
 

--- a/ui/browser/views/tabbar/dragdrop.js
+++ b/ui/browser/views/tabbar/dragdrop.js
@@ -77,6 +77,9 @@ export class TabDragDrop {
     if (item.type === 'text/uri-list' || item.type === 'text/plain') {
       const url = e.dataTransfer.getData(item.type);
 
+      // TODO this whole component needs to be fixed up, and
+      // when navigate to a page, must use NAVIGATE_PAGE_TO action
+      // via `dispatch`.
       const webview = getWebView(e.target.ownerDocument, pageIndex);
       webview.setAttribute('src', url);
 


### PR DESCRIPTION
…a state changes observed by Page. r=vp,linclark

Fixes #119.

This removes most of the usage of different components querying the DOM for the webview, and so only the Page object manages its WebView*. There are still other things grabbing the webview with `getCurrentWebView` but these are for non-navigation components like copy/paste, may need a different solution to clean that up

This feels more Reduxy, and commands are executed as the most recent 'command' (refresh, back, forward, etc) is stored in the Page state, so the Page knows if it needs to fire off a command or not. Is this the right way to do this? Feels nice, having these pretty big deal actions actually reflected in the redux state, though.

Can't assign to @linclark for some reason (?), but would like both of ya @victorporof to take a look at this, because I think this problem will come up again so good to have a pattern for dealing with it