### PR TITLE
Bump electron-prebuilt to 0.37.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "babel-preset-stage-2": "6.5.0",
     "babel-register": "6.7.2",
     "electron-packager": "5.2.1",
-    "electron-prebuilt": "0.37.5",
+    "electron-prebuilt": "0.37.6",
     "electron-rebuild": "1.1.3",
     "enzyme": "2.2.0",
     "eslint": "2.4.0",


### PR DESCRIPTION
Signed-off-by: Brian Grinstead <briangrinstead@gmail.com>