### PR TITLE
Remove babel useless imports

### DIFF
--- a/test/profile/test-storage.js
+++ b/test/profile/test-storage.js
@@ -3,9 +3,6 @@
 
 /* eslint no-console: 0 */
 
-import 'babel-polyfill';
-import 'babel-register';
-
 import expect from 'expect';
 
 import fs from 'fs';

--- a/test/ui/browser/actions/test-attach-tab.js
+++ b/test/ui/browser/actions/test-attach-tab.js
@@ -1,9 +1,6 @@
 // Any copyright is dedicated to the Public Domain.
 // http://creativecommons.org/publicdomain/zero/1.0/
 
-import 'babel-polyfill';
-import 'babel-register';
-
 import expect from 'expect'; // eslint-disable-line
 import configureStore from '../../../../app/ui/browser/store/store';
 import * as actions from '../../../../app/ui/browser/actions/main-actions'; // eslint-disable-line

--- a/test/ui/browser/actions/test-close-tab.js
+++ b/test/ui/browser/actions/test-close-tab.js
@@ -1,9 +1,6 @@
 // Any copyright is dedicated to the Public Domain.
 // http://creativecommons.org/publicdomain/zero/1.0/
 
-import 'babel-polyfill';
-import 'babel-register';
-
 import expect from 'expect';
 import configureStore from '../../../../app/ui/browser/store/store';
 import * as actions from '../../../../app/ui/browser/actions/main-actions';

--- a/test/ui/browser/actions/test-create-tab.js
+++ b/test/ui/browser/actions/test-create-tab.js
@@ -1,9 +1,6 @@
 // Any copyright is dedicated to the Public Domain.
 // http://creativecommons.org/publicdomain/zero/1.0/
 
-import 'babel-polyfill';
-import 'babel-register';
-
 import expect from 'expect';
 import configureStore from '../../../../app/ui/browser/store/store';
 import * as actions from '../../../../app/ui/browser/actions/main-actions';

--- a/test/ui/browser/actions/test-default.js
+++ b/test/ui/browser/actions/test-default.js
@@ -1,9 +1,6 @@
 // Any copyright is dedicated to the Public Domain.
 // http://creativecommons.org/publicdomain/zero/1.0/
 
-import 'babel-polyfill';
-import 'babel-register';
-
 import expect from 'expect';
 import configureStore from '../../../../app/ui/browser/store/store';
 

--- a/test/ui/browser/actions/test-duplicate-tab.js
+++ b/test/ui/browser/actions/test-duplicate-tab.js
@@ -1,9 +1,6 @@
 // Any copyright is dedicated to the Public Domain.
 // http://creativecommons.org/publicdomain/zero/1.0/
 
-import 'babel-polyfill';
-import 'babel-register';
-
 import expect from 'expect';
 import configureStore from '../../../../app/ui/browser/store/store';
 import * as actions from '../../../../app/ui/browser/actions/main-actions';

--- a/test/ui/browser/actions/test-set-current-tab.js
+++ b/test/ui/browser/actions/test-set-current-tab.js
@@ -1,9 +1,6 @@
 // Any copyright is dedicated to the Public Domain.
 // http://creativecommons.org/publicdomain/zero/1.0/
 
-import 'babel-polyfill';
-import 'babel-register';
-
 import expect from 'expect';
 import configureStore from '../../../../app/ui/browser/store/store';
 import * as actions from '../../../../app/ui/browser/actions/main-actions';

--- a/test/ui/browser/actions/test-set-location.js
+++ b/test/ui/browser/actions/test-set-location.js
@@ -1,9 +1,6 @@
 // Any copyright is dedicated to the Public Domain.
 // http://creativecommons.org/publicdomain/zero/1.0/
 
-import 'babel-polyfill';
-import 'babel-register';
-
 import expect from 'expect'; // eslint-disable-line
 import configureStore from '../../../../app/ui/browser/store/store';
 import * as actions from '../../../../app/ui/browser/actions/main-actions'; // eslint-disable-line

--- a/test/ui/browser/actions/test-set-page-area-visibility.js
+++ b/test/ui/browser/actions/test-set-page-area-visibility.js
@@ -1,9 +1,6 @@
 // Any copyright is dedicated to the Public Domain.
 // http://creativecommons.org/publicdomain/zero/1.0/
 
-import 'babel-polyfill';
-import 'babel-register';
-
 import expect from 'expect';
 import configureStore from '../../../../app/ui/browser/store/store';
 import * as actions from '../../../../app/ui/browser/actions/main-actions';

--- a/test/ui/browser/actions/test-set-page-details.js
+++ b/test/ui/browser/actions/test-set-page-details.js
@@ -1,9 +1,6 @@
 // Any copyright is dedicated to the Public Domain.
 // http://creativecommons.org/publicdomain/zero/1.0/
 
-import 'babel-polyfill';
-import 'babel-register';
-
 import expect from 'expect';
 import configureStore from '../../../../app/ui/browser/store/store';
 import * as actions from '../../../../app/ui/browser/actions/main-actions';

--- a/test/ui/browser/actions/test-set-page-order.js
+++ b/test/ui/browser/actions/test-set-page-order.js
@@ -1,9 +1,6 @@
 // Any copyright is dedicated to the Public Domain.
 // http://creativecommons.org/publicdomain/zero/1.0/
 
-import 'babel-polyfill';
-import 'babel-register';
-
 import expect from 'expect';
 
 import configureStore from '../../../../app/ui/browser/store/store';

--- a/test/ui/browser/actions/test-set-user-typed-location.js
+++ b/test/ui/browser/actions/test-set-user-typed-location.js
@@ -1,9 +1,6 @@
 // Any copyright is dedicated to the Public Domain.
 // http://creativecommons.org/publicdomain/zero/1.0/
 
-import 'babel-polyfill';
-import 'babel-register';
-
 import expect from 'expect';
 import configureStore from '../../../../app/ui/browser/store/store';
 import * as actions from '../../../../app/ui/browser/actions/main-actions';


### PR DESCRIPTION
I'm not really sure why we need them, and tests seem to run just fine without.

@ncalexan: I remember you seemed to have to add these in a test a while ago, I wonder why.
@Mossop: You did some work lately on removing webpack and using babel for things, and I don't think it was at all related to how we test things. But apparently we don't need these imports.

Signed-off-by: Victor Porof <vporof@mozilla.com>