### PR TITLE
Remove blue glow on buttons when selected

### DIFF
--- a/app/ui/browser/css/common.css
+++ b/app/ui/browser/css/common.css
@@ -5,3 +5,7 @@ div {
 [hidden] {
   display: none !important;
 }
+
+:focus {
+  outline-style: none;
+}


### PR DESCRIPTION
Signed-off-by: Victor Porof <vporof@mozilla.com>

Seeing this every time we click on a button is probably not very nice:
<img width="703" alt="screen shot 2016-04-20 at 7 48 46 am" src="https://cloud.githubusercontent.com/assets/248899/14664552/5e5de6e8-06cc-11e6-8279-1f0529ea2f24.png">
