### PR TITLE
Fix the package task. Fixes #185. r=mossop

### DIFF
--- a/build/task-package.js
+++ b/build/task-package.js
@@ -16,18 +16,14 @@ const PLATFORM = os.platform();
 
 const IGNORE = [
   // Ignore build stuff
-  '/appveyor.yml',
-  '/branding($|/)',
-  '/build($|/)',
-  '/dist($|/)',
+  '/\/appveyor.yml',
+  '/\/branding($|/)',
+  '/\/build($|/)',
+  '/\/dist($|/)',
   '/electron($|/)',
-  '/gulpfile.js',
   '/README.md',
   '/scripts($|/)',
   '/test($|/)',
-
-  // Ignore source code
-  '/ui($|/)',
 
   // Ignore `/app` and `/shared` once we compile main process code
   // ahead of time, rather than during runtime


### PR DESCRIPTION
This PR:
- makes the paths more explicit so that it doesn't ignore things like `node_modules/immutable/dist/immutable.js`
- un-ignores the ui directory. I'm not sure what change happened to necessitate this, but there's no UI without the ui dir

Is there a better way to keep this list up to date?