### PR TITLE
Pass npm arguments through to mocha to allow selecting specific directories

### DIFF
--- a/build/main.js
+++ b/build/main.js
@@ -32,5 +32,6 @@ if (~process.argv.indexOf('--run')) {
 } else if (~process.argv.indexOf('--package')) {
   Tasks.package().then(null, handleTaskFailed);
 } else if (~process.argv.indexOf('--test')) {
-  Tasks.test().then(null, handleTaskFailed);
+  const taskArgs = process.argv.slice(1 + process.argv.indexOf('--test'));
+  Tasks.test(taskArgs).then(null, handleTaskFailed);
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "node build/main.js --run",
     "dev": "node build/main.js --run-dev",
     "package": "node build/main.js --package",
-    "test": "nyc node build/main.js --test",
+    "test": "nyc -s node build/main.js --test",
+    "report": "nyc report",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "postinstall": "electron-rebuild -f"
   },


### PR DESCRIPTION
This allows us to run individual suites like `npm test test/lint`. We could add a helper that prefixed `test/` on paths if that was helpful.

Fixes #231.

Is this all we need instead of the quick test stuff @joewalker?