### PR TITLE
[WIP] Reduce time spent rerendering when interacting with the page. Fixes #253. r=jsantell

### DIFF
--- a/app/ui/browser/actions/main-actions.js
+++ b/app/ui/browser/actions/main-actions.js
@@ -11,17 +11,20 @@ specific language governing permissions and limitations under the License.
 */
 
 import * as types from '../constants/action-types';
+import { Page } from '../model';
 import * as profileCommands from '../../../shared/profile-commands';
 import { ipcRenderer } from '../../../shared/electron';
 
 export function createTab(location) {
-  return { type: types.CREATE_TAB, location, instrument: true };
+  const page = location ? new Page({ location }) : new Page();
+  return { type: types.CREATE_TAB, page, instrument: true };
 }
 
 export function duplicateTab(pageId) {
   return { type: types.DUPLICATE_TAB, pageId, instrument: true };
 }
 export function attachTab(page) {
+  page = new Page(page);
   return { type: types.ATTACH_TAB, page, instrument: true };
 }
 

--- a/app/ui/browser/model/index.js
+++ b/app/ui/browser/model/index.js
@@ -34,6 +34,8 @@ export const State = Immutable.Record({
   // This is a list of Page objects (see below)
   pages: Immutable.List(),
 
+  pageIds: Immutable.Set(),
+
   // The currently displayed tab
   currentPageIndex: -1,
 

--- a/app/ui/browser/model/index.js
+++ b/app/ui/browser/model/index.js
@@ -14,6 +14,11 @@ import Immutable from 'immutable';
 import uuid from 'uuid';
 
 /**
+ * Fairly sure we should hard code this
+ */
+const HOME_PAGE = 'https://www.mozilla.org/';
+
+/**
  * The browser window's view of its profile.
  */
 export const Profile = Immutable.Record({
@@ -43,7 +48,7 @@ export const State = Immutable.Record({
  */
 export class Page extends Immutable.Record({
   id: null,
-  location: undefined,
+  location: HOME_PAGE,
   title: 'New Tab',
   statusText: false,
   userTyped: null,

--- a/app/ui/browser/reducers/main-reducers.js
+++ b/app/ui/browser/reducers/main-reducers.js
@@ -19,8 +19,10 @@ import { State, Page } from '../model';
 import * as profileDiffTypes from '../../../shared/constants/profile-diff-types';
 import { isUUID } from '../browser-util';
 
+const initialPage = new Page();
 const initialState = new State({
-  pages: Immutable.List.of(new Page()),
+  pages: Immutable.List.of(initialPage),
+  pageIds: Immutable.Set.of(initialPage.id),
   currentPageIndex: 0,
   pageAreaVisible: false,
 });
@@ -91,6 +93,8 @@ function createTab(state, page) {
     mut.update('pages', pages => pages.push(page));
     mut.set('currentPageIndex', state.pages.size);
     mut.set('pageAreaVisible', true);
+
+    mut.update('pageIds', pageIds => pageIds.add(page.id));
   });
 }
 
@@ -109,6 +113,8 @@ function attachTab(state, page) {
   return state.withMutations(mut => {
     mut.set('pages', Immutable.List.of(page));
     mut.set('currentPageIndex', 0);
+
+    mut.update('pageIds', pageIds => pageIds.add(page.id));
   });
 }
 
@@ -129,6 +135,8 @@ function closeTab(state, pageId) {
 
   return state.withMutations(mut => {
     mut.update('pages', pages => pages.delete(pageIndex));
+
+    mut.update('pageIds', pageIds => pageIds.delete(pageId));
 
     // If tab closed comes before our current tab, or if this is the right-most
     // tab and it's selected, decrement the current page index.

--- a/app/ui/browser/reducers/main-reducers.js
+++ b/app/ui/browser/reducers/main-reducers.js
@@ -19,13 +19,8 @@ import { State, Page } from '../model';
 import * as profileDiffTypes from '../../../shared/constants/profile-diff-types';
 import { isUUID } from '../browser-util';
 
-/**
- * Fairly sure we should hard code this
- */
-const HOME_PAGE = 'https://www.mozilla.org/';
-
 const initialState = new State({
-  pages: Immutable.List.of(new Page({ location: HOME_PAGE })),
+  pages: Immutable.List.of(new Page()),
   currentPageIndex: 0,
   pageAreaVisible: false,
 });
@@ -37,7 +32,7 @@ function getPageIndexById(state, id) {
 export default function basic(state = initialState, action) {
   switch (action.type) {
     case types.CREATE_TAB:
-      return createTab(state, action.location);
+      return createTab(state, action.page);
 
     case types.DUPLICATE_TAB:
       return duplicateTab(state, action.pageId);
@@ -91,9 +86,8 @@ export default function basic(state = initialState, action) {
   }
 }
 
-function createTab(state, location = HOME_PAGE) {
+function createTab(state, page) {
   return state.withMutations(mut => {
-    const page = new Page({ location });
     mut.update('pages', pages => pages.push(page));
     mut.set('currentPageIndex', state.pages.size);
     mut.set('pageAreaVisible', true);
@@ -103,16 +97,17 @@ function createTab(state, location = HOME_PAGE) {
 function duplicateTab(state, pageId) {
   assert(isUUID(pageId), 'DUPLICATE_TAB requires a page id.');
 
-  const location = state.pages.get(getPageIndexById(state, pageId)).location;
-  return createTab(state, location);
+  const page = new Page({
+    location: state.pages.get(getPageIndexById(state, pageId)).location,
+  });
+  return createTab(state, page);
 }
 
 function attachTab(state, page) {
   assert(isUUID(page.id), 'ATTACH_TAB requires a page with valid id.');
 
   return state.withMutations(mut => {
-    const newPage = new Page(page);
-    mut.set('pages', Immutable.List.of(newPage));
+    mut.set('pages', Immutable.List.of(page));
     mut.set('currentPageIndex', 0);
   });
 }

--- a/app/ui/browser/views/app.jsx
+++ b/app/ui/browser/views/app.jsx
@@ -22,14 +22,13 @@ const APP_STYLE = Style.registerStyle({
   height: '100%',
 });
 
-const App = function({ profile, currentPageIndex, currentPage, pageAreaVisible, dispatch }) {
+const App = function({ profile, currentPageIndex, pageAreaVisible, dispatch }) {
   return (
     <div className={APP_STYLE}>
       <BrowserWindow ipcRenderer={ipcRenderer}
         dispatch={dispatch}
         profile={profile}
         currentPageIndex={currentPageIndex}
-        currentPage={currentPage}
         pageAreaVisible={pageAreaVisible} />
       <Style.Element />
     </div>
@@ -51,7 +50,6 @@ function mapStateToProps(state) {
   return {
     profile: browserWindow.profile,
     currentPageIndex: browserWindow.currentPageIndex,
-    currentPage: browserWindow.pages.get(browserWindow.currentPageIndex),
     pageAreaVisible: browserWindow.pageAreaVisible,
   };
 }

--- a/app/ui/browser/views/app.jsx
+++ b/app/ui/browser/views/app.jsx
@@ -22,16 +22,15 @@ const APP_STYLE = Style.registerStyle({
   height: '100%',
 });
 
-const App = function({ state, dispatch }) {
+const App = function({ profile, currentPageIndex, currentPage, pageAreaVisible, dispatch }) {
   return (
     <div className={APP_STYLE}>
       <BrowserWindow ipcRenderer={ipcRenderer}
         dispatch={dispatch}
-        profile={state.browserWindow.profile}
-        pages={state.browserWindow.pages}
-        currentPageIndex={state.browserWindow.currentPageIndex}
-        currentPage={state.browserWindow.pages.get(state.browserWindow.currentPageIndex)}
-        pageAreaVisible={state.browserWindow.pageAreaVisible} />
+        profile={profile}
+        currentPageIndex={currentPageIndex}
+        currentPage={currentPage}
+        pageAreaVisible={pageAreaVisible} />
       <Style.Element />
     </div>
   );
@@ -40,12 +39,21 @@ const App = function({ state, dispatch }) {
 App.displayName = 'App';
 
 App.propTypes = {
-  state: PropTypes.object.isRequired,
+  profile: PropTypes.object.isRequired,
+  currentPageIndex: PropTypes.number.isRequired,
+  currentPage: PropTypes.object.isRequired,
+  pageAreaVisible: PropTypes.bool.isRequired,
   dispatch: PropTypes.func.isRequired,
 };
 
 function mapStateToProps(state) {
-  return { state };
+  const browserWindow = state.browserWindow;
+  return {
+    profile: browserWindow.profile,
+    currentPageIndex: browserWindow.currentPageIndex,
+    currentPage: browserWindow.pages.get(browserWindow.currentPageIndex),
+    pageAreaVisible: browserWindow.pageAreaVisible,
+  };
 }
 
 export default connect(mapStateToProps)(Style.component(App));

--- a/app/ui/browser/views/browser.jsx
+++ b/app/ui/browser/views/browser.jsx
@@ -139,7 +139,7 @@ class BrowserWindow extends Component {
             {...this.props } />
         </div>
         <div className={CONTENT_AREA_STYLE}>
-          {pageIds.map((pageId, pageIndex) => (
+          {pageIds.toArray().map((pageId, pageIndex) => (
             <Page key={`page-${pageIndex}`}
               isActive={pageIndex === currentPageIndex}
               pageId={pageId}
@@ -163,9 +163,7 @@ BrowserWindow.propTypes = {
 };
 
 const mapStateToProps = (state) => ({
-  // @TODO restructure the state so this list is automatically created as new todos
-  // are added instead of generated on each update pass
-  pageIds: state.browserWindow.pages.toArray().map(page => page.id),
+  pageIds: state.browserWindow.pageIds,
 });
 
 export default connect(mapStateToProps)(BrowserWindow);

--- a/app/ui/browser/views/browser.jsx
+++ b/app/ui/browser/views/browser.jsx
@@ -11,6 +11,7 @@ specific language governing permissions and limitations under the License.
 */
 
 import React, { PropTypes, Component } from 'react';
+import { connect } from 'react-redux';
 
 import Style from '../browser-style';
 import TabBar from './tabbar/tabbar';
@@ -64,7 +65,7 @@ class BrowserWindow extends Component {
 
   render() {
     const {
-      currentPage, ipcRenderer, dispatch, profile, pages, currentPageIndex, pageAreaVisible,
+      currentPage, ipcRenderer, dispatch, profile, currentPageIndex, pageAreaVisible, pageIds
     } = this.props;
 
     const currentPageId = currentPage.id;
@@ -139,10 +140,10 @@ class BrowserWindow extends Component {
             {...this.props } />
         </div>
         <div className={CONTENT_AREA_STYLE}>
-          {pages.map((page, pageIndex) => (
+          {pageIds.map((pageId, pageIndex) => (
             <Page key={`page-${pageIndex}`}
               isActive={pageIndex === currentPageIndex}
-              page={page}
+              pageId={pageId}
               {...this.props} />
           ))}
         </div>
@@ -153,7 +154,7 @@ class BrowserWindow extends Component {
 }
 
 BrowserWindow.propTypes = {
-  pages: PropTypes.object.isRequired,
+  pageIds: PropTypes.arrayOf(React.PropTypes.string).isRequired,
   currentPage: PropTypes.object.isRequired,
   currentPageIndex: PropTypes.number.isRequired,
   dispatch: PropTypes.func.isRequired,
@@ -162,7 +163,13 @@ BrowserWindow.propTypes = {
   pageAreaVisible: PropTypes.bool.isRequired,
 };
 
-export default BrowserWindow;
+const mapStateToProps = (state) => ({
+  // @TODO restructure the state so this list is automatically created as new todos
+  // are added instead of generated on each update pass
+  pageIds: state.browserWindow.pages.toArray().map(page => page.id),
+});
+
+export default connect(mapStateToProps)(BrowserWindow);
 
 function attachIPCRendererListeners(browserView) {
   const { dispatch, ipcRenderer } = browserView.props;

--- a/app/ui/browser/views/browser.jsx
+++ b/app/ui/browser/views/browser.jsx
@@ -65,7 +65,7 @@ class BrowserWindow extends Component {
 
   render() {
     const {
-      currentPage, ipcRenderer, dispatch, profile, currentPageIndex, pageAreaVisible, pageIds
+      currentPage, ipcRenderer, dispatch, profile, currentPageIndex, pageAreaVisible, pageIds,
     } = this.props;
 
     const currentPageId = currentPage.id;
@@ -153,7 +153,7 @@ class BrowserWindow extends Component {
 }
 
 BrowserWindow.propTypes = {
-  pageIds: PropTypes.arrayOf(React.PropTypes.string).isRequired,
+  pageIds: PropTypes.arrayOf(PropTypes.string).isRequired,
   currentPage: PropTypes.object.isRequired,
   currentPageIndex: PropTypes.number.isRequired,
   dispatch: PropTypes.func.isRequired,

--- a/app/ui/browser/views/browser.jsx
+++ b/app/ui/browser/views/browser.jsx
@@ -54,21 +54,19 @@ class BrowserWindow extends Component {
   }
 
   handleKeyDown({ metaKey, keyCode }) {
-    const { dispatch, currentPage } = this.props;
+    const { dispatch, currentPageId } = this.props;
 
     if (metaKey && keyCode === 70) { // cmd+f
-      dispatch(actions.setPageDetails(currentPage.id, { isSearching: true }));
+      dispatch(actions.setPageDetails(currentPageId, { isSearching: true }));
     } else if (keyCode === 27) { // esc
-      dispatch(actions.setPageDetails(currentPage.id, { isSearching: false }));
+      dispatch(actions.setPageDetails(currentPageId, { isSearching: false }));
     }
   }
 
   render() {
     const {
-      currentPage, ipcRenderer, dispatch, profile, currentPageIndex, pageAreaVisible, pageIds,
+      currentPageId, ipcRenderer, dispatch, profile, currentPageIndex, pageAreaVisible, pageIds,
     } = this.props;
-
-    const currentPageId = currentPage.id;
 
     const navBack = () => dispatch(actions.navigatePageBack(currentPageId));
     const navForward = () => dispatch(actions.navigatePageForward(currentPageId));
@@ -111,7 +109,7 @@ class BrowserWindow extends Component {
     return (
       <div className={BROWSER_WINDOW_STYLE}>
         <div className={CHROME_AREA_STYLE}>
-          <NavBar page={currentPage}
+          <NavBar
             {...{
               navBack,
               navForward,
@@ -154,7 +152,7 @@ class BrowserWindow extends Component {
 
 BrowserWindow.propTypes = {
   pageIds: PropTypes.arrayOf(PropTypes.string).isRequired,
-  currentPage: PropTypes.object.isRequired,
+  currentPageId: PropTypes.number.isRequired,
   currentPageIndex: PropTypes.number.isRequired,
   dispatch: PropTypes.func.isRequired,
   ipcRenderer: PropTypes.object.isRequired,
@@ -162,9 +160,14 @@ BrowserWindow.propTypes = {
   pageAreaVisible: PropTypes.bool.isRequired,
 };
 
-const mapStateToProps = (state) => ({
-  pageIds: state.browserWindow.pageIds,
-});
+const mapStateToProps = (state) => {
+  const browserWindow = state.browserWindow;
+  const currentPage = browserWindow.pages.get(browserWindow.currentPageIndex);
+  return {
+    pageIds: browserWindow.pageIds,
+    currentPageId: currentPage.id,
+  };
+};
 
 export default connect(mapStateToProps)(BrowserWindow);
 

--- a/app/ui/browser/views/browser.jsx
+++ b/app/ui/browser/views/browser.jsx
@@ -120,7 +120,6 @@ class BrowserWindow extends Component {
               minimize,
               maximize,
               close,
-              pages,
               openMenu,
               onLocationChange,
               onLocationContextMenu,

--- a/app/ui/browser/views/navbar/navbar.jsx
+++ b/app/ui/browser/views/navbar/navbar.jsx
@@ -230,9 +230,13 @@ NavBar.propTypes = {
   navigateTo: PropTypes.func.isRequired,
 };
 
-const mapStateToProps = (state) => ({
-  // @TODO get this from the restructured reducer
-  numPages: state.browserWindow.pages.size,
-});
+const mapStateToProps = (state) => {
+  const browserWindow = state.browserWindow;
+  return {
+    // @TODO get this from the restructured reducer
+    numPages: browserWindow.pages.size,
+    page: browserWindow.pages.get(browserWindow.currentPageIndex),
+  };
+};
 
 export default connect(mapStateToProps)(NavBar);

--- a/app/ui/browser/views/navbar/navbar.jsx
+++ b/app/ui/browser/views/navbar/navbar.jsx
@@ -11,6 +11,7 @@ specific language governing permissions and limitations under the License.
 */
 
 import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
 
 import * as UIConstants from '../../constants/ui';
 import Style from '../../browser-style';
@@ -148,7 +149,7 @@ const NavBar = (props) => {
           clickHandler={() => props.setPageAreaVisibility(!props.pageAreaVisible)}>
           <div id="browser-navbar-pages-count"
             className={NAVBAR_PAGES_COUNT_STYLE}>
-            {props.pages.size}
+            {props.numPages}
           </div>
           <span id="browser-navbar-pages-label"
             className={NAVBAR_PAGES_LABEL_STYLE}>
@@ -207,7 +208,7 @@ NavBar.displayName = 'NavBar';
 
 NavBar.propTypes = {
   page: PropTypes.object,
-  pages: PropTypes.object.isRequired,
+  numPages: PropTypes.number.isRequired,
   pageAreaVisible: PropTypes.bool.isRequired,
   ipcRenderer: PropTypes.object.isRequired,
   navBack: PropTypes.func.isRequired,
@@ -229,4 +230,9 @@ NavBar.propTypes = {
   navigateTo: PropTypes.func.isRequired,
 };
 
-export default NavBar;
+const mapStateToProps = (state) => ({
+  // @TODO get this from the restructured reducer
+  numPages: state.browserWindow.pages.size,
+});
+
+export default connect(mapStateToProps)(NavBar);

--- a/app/ui/browser/views/page/page.jsx
+++ b/app/ui/browser/views/page/page.jsx
@@ -135,7 +135,7 @@ Page.propTypes = {
 };
 
 const makeMapStateToProps = (initialState, initialProps) => {
-  const id = initialProps.page.get('id');
+  const id = initialProps.pageId;
   const mapStateToProps = (state) => {
     const pages = state.browserWindow.get('pages');
     const page = pages.find(p => p.id === id);

--- a/app/ui/browser/views/page/page.jsx
+++ b/app/ui/browser/views/page/page.jsx
@@ -11,6 +11,7 @@ specific language governing permissions and limitations under the License.
 */
 
 import React, { PropTypes, Component } from 'react';
+import { connect } from 'react-redux';
 
 import * as UIConstants from '../../constants/ui';
 import Style from '../../browser-style';
@@ -133,7 +134,19 @@ Page.propTypes = {
   ipcRenderer: PropTypes.object.isRequired,
 };
 
-export default Page;
+const makeMapStateToProps = (initialState, initialProps) => {
+  const id = initialProps.page.get('id');
+  const mapStateToProps = (state) => {
+    const pages = state.browserWindow.get('pages');
+    const page = pages.find(p => p.id === id);
+    return {
+      page,
+    };
+  };
+  return mapStateToProps;
+};
+
+export default connect(makeMapStateToProps)(Page);
 
 function addListenersToWebView(webview, page, dispatch, ipcRenderer) {
   webview.addEventListener('did-start-loading', () => {

--- a/app/ui/browser/views/tabbar/tab.jsx
+++ b/app/ui/browser/views/tabbar/tab.jsx
@@ -11,6 +11,7 @@ specific language governing permissions and limitations under the License.
 */
 
 import React, { PropTypes, Component } from 'react';
+import { connect } from 'react-redux';
 
 import Style from '../../browser-style';
 import Btn from '../navbar/btn';
@@ -104,6 +105,7 @@ Tab.displayName = 'Tab';
 
 Tab.propTypes = {
   page: PropTypes.object.isRequired,
+  pageId: PropTypes.string.isRequired,
   isActive: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
   onDragStart: PropTypes.func.isRequired,
@@ -114,4 +116,9 @@ Tab.propTypes = {
   onContextMenu: PropTypes.func.isRequired,
 };
 
-export default Tab;
+const mapStateToProps = (state, ownProps) => ({
+  // @TODO create a selector on the reducer to get this.
+  page: state.browserWindow.get('pages').find(p => p.id === ownProps.pageId),
+});
+
+export default connect(mapStateToProps)(Tab);

--- a/app/ui/browser/views/tabbar/tabbar.jsx
+++ b/app/ui/browser/views/tabbar/tabbar.jsx
@@ -33,7 +33,7 @@ const NEW_TAB_BUTTON_STYLE = Style.registerStyle({
 });
 
 const TabBar = ({
-  pages, currentPageIndex, pageAreaVisible,
+  pageIds, currentPageIndex, pageAreaVisible,
   handleTabContextMenu, handleNewTabClick, handleTabClick, handleTabClose,
 }) => {
   const barDragDrop = { handlers: {} }; // new TabBarDragDrop(pages, dispatch);
@@ -49,7 +49,7 @@ const TabBar = ({
       dragzone="copy string:test/uri-list"
       {...barDragDrop.handlers}>
 
-      {pages.map((page, i) => {
+      {pageIds.map((pageId, i) => {
         // TODO Fix up dragDrop
         const dragDrop = { handlers: {} }; // new TabDragDrop(page, pages, i);
 
@@ -57,10 +57,10 @@ const TabBar = ({
           <Tab key={`browser-tab-${i}`}
             className={`browser-tab-${i}`}
             isActive={currentPageIndex === i}
-            page={page}
-            onClick={handleTabClick(page.id)}
-            onContextMenu={handleTabContextMenu(page.id)}
-            onClose={handleTabClose(page.id)}
+            pageId={pageId}
+            onClick={handleTabClick(pageId)}
+            onContextMenu={handleTabContextMenu(pageId)}
+            onClose={handleTabClose(pageId)}
             {...dragDrop.handlers} />
         );
       })}
@@ -77,7 +77,7 @@ const TabBar = ({
 TabBar.displayName = 'TabBar';
 
 TabBar.propTypes = {
-  pages: PropTypes.object.isRequired,
+  pageIds: PropTypes.arrayOf(PropTypes.string).isRequired,
   currentPageIndex: PropTypes.number.isRequired,
   handleTabClick: PropTypes.func.isRequired,
   handleTabClose: PropTypes.func.isRequired,


### PR DESCRIPTION
As mentioned in #253, we are doing lots of rerenders when the page object changes, which it does frequently because of the `SET_PAGE_DETAIL` and `SET_USER_TYPED_LOCATION` action types.

This PR gives us a big decrease in the amount of time spent.

I created a test which creates 6 additional tabs (7 total) and then sets the status text 3 times.

Before (~37ms):
<img width="1259" alt="perf-tabreload-before" src="https://cloud.githubusercontent.com/assets/105464/14796672/8ed9b7b4-0afc-11e6-978b-015098db45cc.png">

After (~9ms):
<img width="1254" alt="perf-tabreload-after" src="https://cloud.githubusercontent.com/assets/105464/14796745/e7220ba6-0afc-11e6-98fc-f84839c65b6b.png">

If you want to try it yourself, I posted a patch with the [test code](https://gist.github.com/linclark/4171e8483b035c425ed4103a97df4347). Feedback welcome on the testing technique.
