### PR TITLE
Use a unique key when creating <Page> components so we reuse the corr…

### DIFF
--- a/app/ui/browser/views/browser.jsx
+++ b/app/ui/browser/views/browser.jsx
@@ -139,7 +139,7 @@ class BrowserWindow extends Component {
         </div>
         <div className={CONTENT_AREA_STYLE}>
           {pages.map((page, pageIndex) => (
-            <Page key={`page-${pageIndex}`}
+            <Page key={`page-${page.id}`}
               isActive={pageIndex === currentPageIndex}
               page={page}
               {...this.props} />


### PR DESCRIPTION
…ect webview instance to prevent mismatching between webview page and <Page> page. r=linclark

Currently, create two tabs, let's say "a" and "b". Closing "a", and mouse over some links on "b", and the setPageDetails calls are using id "a", which throws in our reducer assertions. We were reusing the same page instance that "a" was using for "b", resulting in this error.