### PR TITLE
User a custom source-map-support in order to get meaningful stack tra…

### DIFF
--- a/app/main/browser.js
+++ b/app/main/browser.js
@@ -13,18 +13,21 @@ specific language governing permissions and limitations under the License.
 */
 
 /* eslint import/imports-first: "off" */
+/* eslint no-console: 0 */
+
 // Must go before any require statements.
 const browserStartTime = Date.now();
 
-/* eslint no-console: 0 */
+import 'source-map-support/register';
 
 process.on('uncaughtException', (err) => {
-  console.log(err.stack);
+  console.error(err.stack);
   process.exit(1);
 });
 
 process.on('unhandledRejection', (reason, p) => {
-  console.log(`Unhandled Rejection at: Promise ${JSON.stringify(p)}, reason: ${reason.stack}`);
+  console.error(`Unhandled Rejection at: Promise ${JSON.stringify(p)}`);
+  console.error(reason.stack);
   process.exit(2);
 });
 

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "react-addons-perf": "15.0.1",
     "react-addons-test-utils": "15.0.1",
     "rimraf": "2.5.2",
+    "source-map-support": "ncalexan/node-source-map-support#fileUrls-plus",
     "spectron": "1.37.0",
     "through2": "2.0.1",
     "tmp": "0.0.28",


### PR DESCRIPTION
…ces.

The source-map-support package doesn't appreciate absolute file://
URLs.  I tried to address this in
https://github.com/evanw/node-source-map-support/issues/133 and made
some progress before discovering
https://github.com/evanw/node-source-map-support/pull/126.  I pushed
that work, and a small follow-up, to my local version used here.

With this, I get stack traces that referring to app/.