### PR TITLE
Add --force to build, and allow specifying particular files to build.

### DIFF
--- a/build/main.js
+++ b/build/main.js
@@ -31,7 +31,8 @@ require('check-dependencies')((result) => {
   const Tasks = require('./tasks').default;
 
   if (~process.argv.indexOf('--build')) {
-    Tasks.build().then(null, handleTaskFailed);
+    const taskArgs = process.argv.slice(1 + process.argv.indexOf('--build'));
+    Tasks.build({}, taskArgs).then(null, handleTaskFailed);
   } else if (~process.argv.indexOf('--run')) {
     const taskArgs = process.argv.slice(1 + process.argv.indexOf('--run'));
     Tasks.run(taskArgs).then(null, handleTaskFailed);

--- a/build/tasks.js
+++ b/build/tasks.js
@@ -17,14 +17,14 @@ export default {
     await require('./task-build-deps').default();
   },
 
-  async build(config = {}) {
+  async build(config = {}, args = []) {
     await this.config(config);
-    await require('./task-build').default();
+    await require('./task-build').default(args);
   },
 
-  async buildDev() {
+  async buildDev(args = []) {
     await this.config({ development: true });
-    await require('./task-build').default();
+    await require('./task-build').default(args);
   },
 
   async run(args = []) {


### PR DESCRIPTION
The force flag makes it easier to test.

Specifying one particular file improves File Watchers in IDEA WebStorm.
On changes, I can transparently transpile a single file, ready for
running or launching a test without requiring a full build.