### PR TITLE
Turns on 32-bit windows builds on AppVeyor.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,7 @@
-platform: x64
+platform:
+  - x86
+  - x64
+
 image: Visual Studio 2013
 os: unstable
 
@@ -20,7 +23,7 @@ install:
   - ps: Install-Product node $env:nodejs_version $env:PLATFORM
   - node --version
   - npm --version
-  - set npm_config_arch=%PLATFORM%
+  - set npm_config_arch=%PLATFORM:x86=ia32%
   - npm install --progress false --depth 0
 
 build: off

--- a/build/task-package.js
+++ b/build/task-package.js
@@ -11,7 +11,7 @@ import zip from 'gulp-vinyl-zip';
 
 import * as BuildUtils from './utils';
 
-const ARCH = 'x64';
+const ARCH = process.arch;
 const PLATFORM = os.platform();
 
 const ROOT = path.resolve(path.join(__dirname, '..'));


### PR DESCRIPTION
Node has an oddity in that it uses "ia32" instead of "x86" as the identifier for
32-bit builds so we have to transplate the platform environment variable
accordingly.

Fixes #312.