### PR TITLE
Support downloading a custom build of electron.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ build-config.json
 .nyc_output/
 *~
 /browser.db
+.electron
+.cache

--- a/build/task-config-builder.js
+++ b/build/task-config-builder.js
@@ -6,13 +6,10 @@
  * build configurations.
  */
 
-import path from 'path';
 import os from 'os';
 import fs from 'fs-promise';
 
 import * as BuildUtils from './utils';
-
-export const BUILD_CONFIG_JSON = path.join(__dirname, '..', 'build-config.json');
 
 const BASE_CONFIG = {
   // System information
@@ -54,12 +51,12 @@ export default async function(config) {
   let currentConfig = {};
 
   try {
-    currentConfig = await fs.readJson(BUILD_CONFIG_JSON);
+    currentConfig = await fs.readJson(BuildUtils.getBuildConfigFile());
   } catch (e) {
     // Ignore missing file errors.
   }
 
   const configToWrite = Object.assign({}, currentConfig, BASE_CONFIG, config);
 
-  await fs.writeJson(BUILD_CONFIG_JSON, configToWrite, { spaces: 2 });
+  await fs.writeJson(BuildUtils.getBuildConfigFile(), configToWrite, { spaces: 2 });
 }

--- a/build/task-package.js
+++ b/build/task-package.js
@@ -67,6 +67,11 @@ export default async function() {
   const electronVersion = BuildUtils.getElectronVersion();
   const appVersion = BuildUtils.getAppVersion();
 
+  const downloadOptions = BuildUtils.getDownloadOptions();
+
+  // packager displays a warning if this property is set.
+  delete downloadOptions.version;
+
   const packagedApp = await packageApp({
     arch: ARCH,
     platform: PLATFORM,
@@ -76,6 +81,7 @@ export default async function() {
     dir: ROOT,
     icon: path.join(ROOT, 'branding', 'app-icon'),
     out: path.join(ROOT, 'dist'),
+    download: downloadOptions,
   });
 
   const packageName = `${manifest.name}-${appVersion}-${PLATFORM}-${ARCH}.zip`;

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Experimental prototype",
   "main": "lib/main/browser.js",
   "repository": "https://github.com/mozilla/tofino",
+  "_electron": {
+    "version": "0.37.8"
+  },
   "scripts": {
     "start": "node build/main.js --run",
     "dev": "node build/main.js --run-dev",
@@ -12,8 +15,8 @@
     "quicktest": "nyc node build/main.js --quicktest",
     "report": "nyc report",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
-    "install": "node build/main.js --build",
-    "postinstall": "node build/main.js --build-deps"
+    "install": "node build/main.js --build-deps",
+    "postinstall": "node build/main.js --build"
   },
   "license": "Apache-2.0",
   "dependencies": {
@@ -44,9 +47,9 @@
     "check-dependencies": "0.12.0",
     "chokidar": "1.4.3",
     "coveralls": "2.11.9",
+    "electron-download": "2.1.2",
     "electron-ipc-mock": "0.0.1",
     "electron-packager": "7.0.0",
-    "electron-prebuilt": "0.37.6",
     "electron-rebuild": "1.1.3",
     "enzyme": "2.2.0",
     "eslint": "2.4.0",
@@ -56,6 +59,7 @@
     "eslint-plugin-react": "4.2.3",
     "expect": "1.18.0",
     "express": "4.13.4",
+    "extract-zip": "1.5.0",
     "fs-promise": "0.5.0",
     "glob": "7.0.3",
     "gulp-vinyl-zip": "1.2.2",


### PR DESCRIPTION
Drops the electron-prebuilt dependency and instead manually checks the installed
electron version and if incorrect downloads with electron-download. We cache
the download locally to tofino since the global cache could affect other
applications on a developer's machine. Currently this doesn't change where
electron is downloaded from but once we have builds available we can just set
the electron-download options to point to them.