### PR TITLE
Reset selected autocomplete index when the typed input changes

### DIFF
--- a/app/ui/browser/views/navbar/location.jsx
+++ b/app/ui/browser/views/navbar/location.jsx
@@ -121,6 +121,16 @@ export class Location extends Component {
     this.props.ipcRenderer.on('focus-urlbar', () => this.refs.input.select());
   }
 
+  componentWillReceiveProps(nextProps) {
+    // Reset the focused result if the input has changed (so that an index doesn't
+    // get reused over a different result set).
+    // focusedResultIndex may want to be moved to redux a la userTypedLocation,
+    // depending on the eventual UX and if anywhere else would want to change it.
+    if (this.props.userTypedLocation !== nextProps.userTypedLocation) {
+      this.setState({ focusedResultIndex: -1 });
+    }
+  }
+
   componentDidUpdate() {
     // If we're showing the URL bar, it should be focused. The scenario
     // where this isn't true is immediately after displaying the URL bar,

--- a/test/ui/browser/views/navbar/test-location.js
+++ b/test/ui/browser/views/navbar/test-location.js
@@ -88,5 +88,17 @@ describe('Location', () => {
       expect(wrapper.find('#autocomplete-results').childAt(0).text()).toEqual('https://mozilla.com');
       expect(wrapper.find('#autocomplete-results').childAt(1).text()).toEqual('https://mozilla.org');
     });
+
+    it('should reset the selected index when input changes', () => {
+      const props = createSpyProps();
+      props.userTypedLocation = 'm';
+      const wrapper = shallow(
+        <Location {...props} />
+      );
+      props.userTypedLocation = 'mo';
+      wrapper.setState({ showURLBar: true, focusedURLBar: true, focusedResultIndex: 1 });
+      wrapper.setProps(props);
+      expect(wrapper.state('focusedResultIndex')).toEqual(-1);
+    });
   });
 });


### PR DESCRIPTION
r? @jsantell.

This fixes a situation where you have hovered / navigated to a result, then change the input so that there aren't as many results.  i.e. you can end up in a situation where the focused result = 4 but the number of results = 2.

We could possibly move the entire focusedResultIndex machinery up to redux but I'm not sure if that's what we'll want long term, so this is a quick and easy fix to improve the UX.