### PR TITLE
Increase default homepage horizontal padding

### DIFF
--- a/app/ui/about/mozilla.html
+++ b/app/ui/about/mozilla.html
@@ -16,6 +16,10 @@
         min-height: 100%;
       }
 
+      body {
+        padding: 0 10%;
+      }
+
       #moztext {
         margin-top: 15%;
         font-size: 1.1em;


### PR DESCRIPTION
The homepage text gets too close to the left and right browser edges, at least for my taste.  This increases the spacing, making things look a bit more spacious.

<img width="1377" alt="screenshot at may 04 20-12-05" src="https://cloud.githubusercontent.com/assets/46655/15033769/3fbca468-1234-11e6-8c96-48498be6e2fc.png">
