### PR TITLE
Use `redux-immutable` to have the aggregate UI state be an immutable …

### DIFF
--- a/app/ui/browser/index.jsx
+++ b/app/ui/browser/index.jsx
@@ -17,16 +17,10 @@ import { ipcRenderer } from '../../shared/electron';
 
 import App from './views/app';
 import configureStore from './store/store';
-import rootReducer from './reducers';
 import * as actions from './actions/main-actions';
 import * as profileDiffs from '../../shared/profile-diffs';
 
-const initialProfileState = ipcRenderer.sendSync('window-loaded');
-
-// This gets a "blank" state that may not be renderable.
-const initialState = rootReducer(undefined, { type: null });
-
-const store = configureStore(initialState);
+const store = configureStore();
 
 // Before rendering, add a fresh tab and prepare the cached profile data.  This is leading toward a
 // session restore model where the main process can instantiate a mostly-formed browser window.
@@ -34,6 +28,8 @@ const store = configureStore(initialState);
 // can't necessarily produce the resulting state (which is supposed to be the initial state
 // presented to the user).  Dispatching actions also uses the same codepaths the rest of the
 // application uses.
+
+const initialProfileState = ipcRenderer.sendSync('window-loaded');
 
 store.dispatch(profileDiffs.bookmarks(initialProfileState.bookmarks));
 store.dispatch(actions.createTab());

--- a/app/ui/browser/model/index.js
+++ b/app/ui/browser/model/index.js
@@ -67,3 +67,12 @@ export const UIState = Immutable.Record({
   // What the user has typed into the location bar, stored by page id
   userTypedLocation: Immutable.Map(),
 });
+
+/**
+ * Aggregate state.  Keep this synchronized with ../reducers/index.js!
+ */
+export const State = Immutable.Record({
+  pages: new Pages(),
+  profile: new Profile(),
+  uiState: new UIState(),
+});

--- a/app/ui/browser/reducers/index.js
+++ b/app/ui/browser/reducers/index.js
@@ -10,11 +10,15 @@ CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 */
 
-import { combineReducers } from 'redux';
+import { combineReducers } from 'redux-immutable';
+
 import pages from './pages';
 import profile from './profile';
 import uiState from './ui-state';
 
+/**
+ * Aggregate reducer.  Keep this synchronized with ../model/index.js!
+ */
 const rootReducer = combineReducers({
   pages,
   profile,

--- a/app/ui/browser/store/store.js
+++ b/app/ui/browser/store/store.js
@@ -14,6 +14,7 @@ import { applyMiddleware, createStore } from 'redux';
 import createLogger from 'redux-logger';
 import rootReducer from '../reducers';
 import thunk from '../../../shared/thunk';
+import * as model from '../model/index';
 import * as instrument from '../../shared/instrument';
 import BUILD_CONFIG from '../../../../build-config';
 
@@ -33,16 +34,18 @@ export default function configureStore(initialState) {
       duration: true,
       collapsed: true,
       stateTransformer(state) {
-        // combineReducers composes a JS object.  Assume each composed state object is an Immutable
-        // instance.
-        const transformed = {};
-        Object.keys(state).forEach((key) => {
-          transformed[key] = state[key].toJS();
-        });
-        return transformed;
+        return state.toJS();
       },
     }));
   }
+
+  if (!initialState) {
+    // This gets a "blank" state that may not be renderable.
+    initialState = rootReducer(undefined, { type: null });
+  }
+
+  // We want a Record, not just a Map.  Upgrade!
+  initialState = new model.State(initialState);
 
   const store = createStore(rootReducer, initialState, applyMiddleware(...middleware));
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "react-free-style": "2.1.1",
     "react-redux": "4.4.5",
     "redux": "3.5.1",
+    "redux-immutable": "3.0.6",
     "redux-logger": "2.6.1",
     "request": "2.71.0",
     "sqlite3": "3.1.3",


### PR DESCRIPTION
…Record.

This is just hygiene, consistency, and future-looking uniformization.
Mostly I was irritated that I couldn't just .toJS() the UI state!

There's a bit of hoop-jumping to use a new Record type rather than an
immutable Map.  It's worth it to expose `.member`, rather than requiring
`.get('member')` everywhere.  I hope to make this type checked in the
future.

redux-immutable is quite light and has no further dependencies.  I see
no reason to write our own equivalent, or to fold it into our package
directly.