### PR TITLE
Set input value when userTypedLocation changes externally

### DIFF
--- a/app/ui/browser/actions/external.js
+++ b/app/ui/browser/actions/external.js
@@ -82,7 +82,7 @@ export function menuBrowser(pageSessionId, dispatch) {
 /**
  * Right click on the location bar
  */
-export function menuLocationContext(input, dispatch) {
+export function menuLocationContext(input, pageId, dispatch) {
   const menu = new Menu();
 
   menu.append(new MenuItem({
@@ -96,9 +96,8 @@ export function menuLocationContext(input, dispatch) {
       const value = input.value;
       clipboard.writeText(value.slice(input.selectionStart, input.selectionEnd));
       const loc = value.slice(0, input.selectionStart) + value.slice(input.selectionEnd);
-      dispatch(setUserTypedLocation({
-        pageIndex: -1,
-        userTyped: loc,
+      dispatch(setUserTypedLocation(pageId, {
+        text: loc,
       }));
     },
   }));
@@ -108,9 +107,8 @@ export function menuLocationContext(input, dispatch) {
     click: () => {
       const before = input.value.slice(0, input.selectionStart);
       const after = input.value.slice(input.selectionEnd);
-      dispatch(setUserTypedLocation({
-        pageIndex: -1,
-        userTyped: `${before}${clipboard.readText()}${after}`,
+      dispatch(setUserTypedLocation(pageId, {
+        text: `${before}${clipboard.readText()}${after}`,
       }));
     },
   }));
@@ -121,11 +119,10 @@ export function menuLocationContext(input, dispatch) {
       const before = input.value.slice(0, input.selectionStart);
       const after = input.value.slice(input.selectionEnd);
       const loc = before + clipboard.readText() + after;
-      dispatch(setUserTypedLocation({
-        pageIndex: -1,
-        userTyped: loc,
+      dispatch(setUserTypedLocation(pageId, {
+        text: loc,
       }));
-      dispatch(navigatePageTo(-1, fixURL(loc)));
+      dispatch(navigatePageTo(pageId, fixURL(loc)));
     },
   }));
 

--- a/app/ui/browser/views/browser.jsx
+++ b/app/ui/browser/views/browser.jsx
@@ -83,7 +83,7 @@ class BrowserWindow extends Component {
         text,
       }));
     };
-    const onLocationContextMenu = e => menuLocationContext(e.target, dispatch);
+    const onLocationContextMenu = e => menuLocationContext(e.target, currentPageId, dispatch);
     const onLocationReset = () => {
       dispatch(actions.setUserTypedLocation(currentPageId, { text: void 0 }));
     };

--- a/app/ui/browser/views/navbar/location.jsx
+++ b/app/ui/browser/views/navbar/location.jsx
@@ -117,6 +117,15 @@ export class Location extends Component {
     // depending on the eventual UX and if anywhere else would want to change it.
     if (this.props.userTypedLocation !== nextProps.userTypedLocation) {
       this.setState({ focusedResultIndex: -1 });
+
+      // this happens when userTypedLocation changed outside of a 'normal' input
+      // change i.e. 'paste' context menu.  Need to make sure the input is actually set.
+      // No tests for this right now, since shallow rendering doesn't support 'refs'.
+      if (this.refs.input &&
+          nextProps.userTypedLocation &&
+          this.refs.input.value !== nextProps.userTypedLocation) {
+        this.setInputValue(nextProps.userTypedLocation);
+      }
     }
   }
 

--- a/test/ui/browser/views/navbar/test-location.js
+++ b/test/ui/browser/views/navbar/test-location.js
@@ -100,5 +100,9 @@ describe('Location', () => {
       wrapper.setProps(props);
       expect(wrapper.state('focusedResultIndex')).toEqual(-1);
     });
+
+    // Pending test due to not being able to use refs in shallow rendering
+    // See https://github.com/mozilla/tofino/pull/385.
+    it('should set the input value when userTypedLocation changes externally');
   });
 });


### PR DESCRIPTION
Fixes #356.

@jsantell I can't think of a good way to test this.

* Context menu actions - AFAIK we can't trigger the context menus in our tests.  This seems like the kind of thing Flow should help with (the parameter order / types regressed at some point when calling functions that *do* have type annotations), but I couldn't get it to actually complain about much trying.
* The input value setting - this is hooking into componentWillReceiveProps to force the input's value to update if userTypedLocation has changed in some manner other than input being received in the text box.  Shallow rendering doesn't support refs though (https://facebook.github.io/react/docs/test-utils.html#shallow-rendering) so we can't cover it from our unit tests.