### PR TITLE
Readability: fix text extraction. (#405) r=bgrins

### DIFF
--- a/app/content/preload/readability.js
+++ b/app/content/preload/readability.js
@@ -76,15 +76,8 @@ var Readability = function(uri, doc, options) {
       return rv + elDesc;
     };
     this.log = function () {
-      if ("dump" in root) {
-        var msg = Array.prototype.map.call(arguments, function(x) {
-          return (x && x.nodeName) ? logEl(x) : x;
-        }).join(" ");
-        dump("Reader: (Readability) " + msg + "\n");
-      } else if ("console" in root) {
-        var args = ["Reader: (Readability) "].concat(arguments);
-        console.log.apply(console, args);
-      }
+      var args = ["Reader: (Readability) "].concat(arguments);
+      console.log.apply(console, args);
     };
   } else {
     this.log = function () {};
@@ -694,7 +687,7 @@ Readability.prototype = {
           } else {
             // EXPERIMENTAL
             this._forEachNode(node.childNodes, function(childNode) {
-              if (childNode.nodeType === Node.TEXT_NODE) {
+              if (childNode.nodeType === childNode.TEXT_NODE) {
                 var p = doc.createElement('p');
                 p.textContent = childNode.textContent;
                 p.style.display = 'inline';
@@ -1775,12 +1768,12 @@ Readability.prototype = {
         return;
       }
 
-      if (e.nodeType === Node.TEXT_NODE) {
+      if (e.nodeType === e.TEXT_NODE) {
         acc.push(e.data);
         return;
       }
 
-      if (e.nodeType !== Node.ELEMENT_NODE) {
+      if (e.nodeType !== e.ELEMENT_NODE) {
         return;
       }
 

--- a/app/content/preload/readability.js
+++ b/app/content/preload/readability.js
@@ -1770,32 +1770,31 @@ Readability.prototype = {
    */
   _textContentWithNewlines: function (elem) {
     var acc = [];
-    function pushContent(e) {
-      var t = e.textContent;
-      if (t) {
-        acc.push(t);
-      }
-    }
-
     function accumulate(e) {
       if (!e) {
         return;
       }
 
-      if (e.tagName == "P") {
-        pushContent(e);
-        acc.push("\n\n");
+      if (e.nodeType === Node.TEXT_NODE) {
+        acc.push(e.data);
         return;
       }
 
-      if (e.hasChildNodes && e.hasChildNodes()) {
-        for (var i = 0; i < e.children.length; ++i) {
-          accumulate(e.children[i]);
+      if (e.nodeType !== Node.ELEMENT_NODE) {
+        return;
+      }
+
+      // This should always be the case for any elements that have
+      // content.
+      if (e.childNodes.length > 0) {
+        for (var i = 0; i < e.childNodes.length; ++i) {
+          accumulate(e.childNodes[i]);
         }
-        return;
-      }
 
-      pushContent(e);
+        if (e.tagName == "P") {
+          acc.push("\n\n");
+        }
+      }
     }
 
     accumulate(elem);

--- a/test/ui/model/test-readability.js
+++ b/test/ui/model/test-readability.js
@@ -1,0 +1,69 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+import expect from 'expect';
+import Readability from '../../../app/content/preload/readability.js';
+import jsdom from 'jsdom';
+
+describe('Readability', () => {
+  it('Is barely functional', (done) => {
+    const sampleDoc = `
+<html>
+<head>
+<title>Hello, world</title>
+</head>
+<body>
+<div class="main">
+<h1 class="header">The article goes here</h1>
+<div class="article">
+Here is some text
+<p>Here is a paragraph <b>with bold</b> and
+lots and lots and lots and lots of text
+and lots more and lots more
+and lots and lots and lots</p>
+<p>Here is a paragraph <b>with bold</b> and
+lots and lots and lots and lots of text
+and lots more and lots more
+and lots and lots and lots</p>
+<p>Here is a paragraph <b>with bold</b> and
+lots and lots and lots and lots of text
+and lots more and lots more
+and lots and lots and lots</p>
+and some more
+<p>Here is a paragraph <b>with bold</b> and
+lots and lots and lots and lots of text
+and lots more and lots more
+and lots and lots and lots</p>
+and some more
+<p>Here is a paragraph <b>with bold</b> and
+lots and lots and lots and lots of text
+and lots more and lots more
+and lots and lots and lots</p>
+and some more
+<p>Here is a paragraph <b>with bold</b> and
+lots and lots and lots and lots of text
+and lots more and lots more
+and lots and lots and lots</p>
+and some more
+<ul><li>Hello</li><li>World</li></ul>
+Eat
+</div>
+</div>
+</body>
+</html>`;
+    jsdom.env({
+      html: sampleDoc,
+      url: 'http://example.com/foo/',
+      done: (errors, window) => {
+        const result = new Readability(
+          'http://example.com/foo/',
+          window.document).parse();
+        expect(result.title).toBe('Hello, world');
+        expect(result.excerpt).toBe('Here is some text');
+        expect(result.textContent).toMatch(
+          /^Here is some text\n\n\nHere is a paragraph with bold and\nlots/);
+        done();
+      },
+    });
+  });
+});


### PR DESCRIPTION
This passes my own ad-hoc testing by dumping the function into the Firefox web console and making a heinous mishmash of `<li>`, `<p>`, and text nodes.