### PR TITLE
Wait for a page's session id on all user agent requests. r=nalexander

### DIFF
--- a/app/ui/browser/actions/main-actions.js
+++ b/app/ui/browser/actions/main-actions.js
@@ -37,7 +37,7 @@ export function createTab(location: ?string = undefined,
     dispatch({ type: types.CREATE_TAB, id, ancestorId, location, options, instrument: true });
 
     // TODO: properly track window scope.
-    userAgent.createSession({ ancestor: ancestorId, reason }).then(({ session }) =>
+    userAgent.createSession(id, { ancestor: ancestorId, reason }).then(({ session }) =>
       dispatch(didStartSession(id, session, ancestorId)));
   };
 }
@@ -65,7 +65,7 @@ export function closeTab(pageId: string): Action {
     // Notify User Agent with sessionId before closing the tab (and losing the sessionId).
     const page = getPageById(getState(), pageId);
     if (page) {
-      userAgent.destroySession({ session: page.sessionId, reason });
+      userAgent.destroySession(page, { reason });
     }
 
     dispatch({ type: types.CLOSE_TAB, pageId, instrument: true });
@@ -140,21 +140,23 @@ export function setUserTypedLocation(pageId: string, payload: Object): Action {
   };
 }
 
-export function bookmark(session: number, url: string, title: ?string = undefined): Action {
-  return dispatch => {
+export function bookmark(pageId: number, url: string, title: ?string = undefined): Action {
+  return (dispatch, getState) => {
     // Update this window's state before telling the profile service.
     dispatch({ type: types.SET_BOOKMARK_STATE, url, isBookmarked: true, title });
 
-    userAgent.createStar({ session, url, title });
+    const page = getPageById(getState(), pageId);
+    userAgent.createStar(page, { url, title });
   };
 }
 
-export function unbookmark(session: number, url: string): Action {
-  return dispatch => {
+export function unbookmark(pageId: number, url: string): Action {
+  return (dispatch, getState) => {
     // Update this window's state before telling the profile service.
     dispatch({ type: types.SET_BOOKMARK_STATE, url, isBookmarked: false });
 
-    userAgent.destroyStar({ session, url });
+    const page = getPageById(getState(), pageId);
+    userAgent.destroyStar(page, { url });
   };
 }
 

--- a/app/ui/browser/views/browser.jsx
+++ b/app/ui/browser/views/browser.jsx
@@ -74,8 +74,8 @@ class BrowserWindow extends Component {
       navigateTo: location => webViewController.navigateTo(currentPage.id, location),
 
       // Boorkmark handling methods.
-      bookmark: (title, url) => dispatch(actions.bookmark(currentPage.sessionId, url, title)),
-      unbookmark: url => dispatch(actions.unbookmark(currentPage.sessionId, url)),
+      bookmark: (title, url) => dispatch(actions.bookmark(currentPage.id, url, title)),
+      unbookmark: url => dispatch(actions.unbookmark(currentPage.id, url)),
       isBookmarked: url => profile.bookmarks.has(url),
 
       // NavBar methods.

--- a/app/ui/browser/views/page/page.jsx
+++ b/app/ui/browser/views/page/page.jsx
@@ -63,10 +63,9 @@ class Page extends Component {
           return;
         }
 
-        userAgent.createPage({
+        userAgent.createPage(this.props.page, {
           url: readerResult.uri,
-          session: page.sessionId,
-          page: readerResult,
+          readerResult,
         });
       });
     });
@@ -163,7 +162,7 @@ function addListenersToWebView(webview, pageAccessor, dispatch) {
       text: null,
     }));
 
-    userAgent.createHistory({ url, title, session: pageAccessor().sessionId });
+    userAgent.createHistory(pageAccessor(), { url, title });
   });
 
   webview.addEventListener('ipc-message', e => {


### PR DESCRIPTION
This does what we talked about. The inclusion of the deferred library is to prevent nested Promise constructors, and it still uses native promises and is rather short.