### PR TITLE
Make the main menu open from the hamburger button too.

### DIFF
--- a/app/main/menu/menus.js
+++ b/app/main/menu/menus.js
@@ -1,0 +1,116 @@
+/*
+Copyright 2016 Mozilla
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License. You may obtain a copy of the
+License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/
+
+/**
+ * A series of template objects used in Electron's menu creation, or
+ * a function that takes in data and returns a template object.
+ *
+ * @see https://electron.atom.io/docs/latest/api/menu/
+ */
+
+import electron from 'electron';
+import items from './submenu-items';
+const APP_NAME = electron.app.getName();
+
+const menus = {
+  file: {
+    label: 'File',
+    submenu: [
+      items.newTab,
+      items.newWindow,
+      items.capturePage,
+    ],
+  },
+  edit: {
+    label: 'Edit',
+    submenu: [
+      items.undo,
+      items.redo,
+      items.separator,
+      items.cut,
+      items.copy,
+      items.paste,
+      items.selectAll,
+    ],
+  },
+  view: {
+    label: 'View',
+    submenu: [
+      items.toggleFullScreen,
+    ],
+  },
+  history: {
+    label: 'History',
+    submenu: [
+      items.showHistory,
+      items.separator,
+    ],
+  },
+  bookmarks: (data) => {
+    const bookmarksMenu = {
+      label: 'Bookmarks',
+      submenu: [
+        items.showBookmarks,
+        items.separator,
+      ],
+    };
+
+    if (data.recentBookmarks) {
+      data.recentBookmarks.reduce((submenu, bookmark) => {
+        submenu.push(items.openBookmark(bookmark));
+        return submenu;
+      }, bookmarksMenu.submenu);
+    }
+
+    return bookmarksMenu;
+  },
+  tools: {
+    label: 'Tools',
+    submenu: [
+      items.reloadApp,
+      items.toggleDevTools,
+    ],
+  },
+  window: {
+    label: 'Window',
+    role: 'window',
+    submenu: [
+      items.minimizeWindow,
+      items.closeTab,
+      items.separator,
+      items.bringAllToFront,
+    ],
+  },
+  help: {
+    label: 'Help',
+    role: 'help',
+    submenu: [
+      items.learnMore,
+    ],
+  },
+  osx: {
+    label: APP_NAME,
+    submenu: [
+      items.osx.about,
+      items.separator,
+      items.osx.services,
+      items.separator,
+      items.osx.hide,
+      items.osx.hideOthers,
+      items.osx.showAll,
+      items.separator,
+      items.osx.quit,
+    ],
+  },
+};
+
+export default menus;

--- a/app/main/menu/submenu-items.js
+++ b/app/main/menu/submenu-items.js
@@ -56,6 +56,11 @@ items.newWindow = {
   click: openNewWindow,
 };
 
+items.capturePage = {
+  label: 'Fetch page contents',
+  click: (item, focusedWindow) => focusedWindow.webContents.send('capture-page'),
+};
+
 items.undo = {
   label: 'Undo',
   accelerator: 'CmdOrCtrl+Z',

--- a/app/main/menu/template.js
+++ b/app/main/menu/template.js
@@ -10,105 +10,38 @@ CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 */
 
-import electron from 'electron';
-import items from './submenu-items';
-const APP_NAME = electron.app.getName();
+import menus from './menus';
 
-/**
- * A hash of keys mapping to a template object used by Electron's menu API, or
- * a function that takes in data and returns a template object.
- *
- * @see https://electron.atom.io/docs/latest/api/menu/
- */
-const BrowserMenuTemplate = {
-  file: {
-    label: 'File',
-    submenu: [
-      items.newTab,
-      items.newWindow,
-    ],
-  },
-  edit: {
-    label: 'Edit',
-    submenu: [
-      items.undo,
-      items.redo,
-      items.separator,
-      items.cut,
-      items.copy,
-      items.paste,
-      items.selectAll,
-    ],
-  },
-  view: {
-    label: 'View',
-    submenu: [
-      items.toggleFullScreen,
-    ],
-  },
-  history: {
-    label: 'History',
-    submenu: [
-      items.showHistory,
-      items.separator,
-    ],
-  },
-  bookmarks: (data) => {
-    const bookmarksMenu = {
-      label: 'Bookmarks',
-      submenu: [
-        items.showBookmarks,
-        items.separator,
-      ],
-    };
+export const MinimalAppMenuTemplate = [
+  menus.file,
+  menus.edit,
+  menus.window,
+  menus.help,
+];
 
-    if (data.recentBookmarks) {
-      data.recentBookmarks.reduce((submenu, bookmark) => {
-        submenu.push(items.openBookmark(bookmark));
-        return submenu;
-      }, bookmarksMenu.submenu);
-    }
+export const AppMenuTemplate = [
+  menus.file,
+  menus.edit,
+  menus.view,
+  menus.history,
+  menus.bookmarks,
+  menus.tools,
+  menus.window,
+  menus.help,
+];
 
-    return bookmarksMenu;
-  },
-  tools: {
-    label: 'Tools',
-    submenu: [
-      items.reloadApp,
-      items.toggleDevTools,
-    ],
-  },
-  window: {
-    label: 'Window',
-    role: 'window',
-    submenu: [
-      items.minimizeWindow,
-      items.closeTab,
-      items.separator,
-      items.bringAllToFront,
-    ],
-  },
-  help: {
-    label: 'Help',
-    role: 'help',
-    submenu: [
-      items.learnMore,
-    ],
-  },
-  osx: {
-    label: APP_NAME,
-    submenu: [
-      items.osx.about,
-      items.separator,
-      items.osx.services,
-      items.separator,
-      items.osx.hide,
-      items.osx.hideOthers,
-      items.osx.showAll,
-      items.separator,
-      items.osx.quit,
-    ],
-  },
-};
+export const WindowMenuTemplate = [
+  ...menus.file.submenu,
+  menus.edit,
+  menus.view,
+  menus.history,
+  menus.bookmarks,
+  menus.tools,
+  menus.window,
+  menus.help,
+];
 
-export default BrowserMenuTemplate;
+if (process.platform === 'darwin') {
+  MinimalAppMenuTemplate.unshift(menus.osx);
+  AppMenuTemplate.unshift(menus.osx);
+}

--- a/app/ui/browser/actions/external.js
+++ b/app/ui/browser/actions/external.js
@@ -15,7 +15,6 @@ specific language governing permissions and limitations under the License.
 import * as actions from './main-actions';
 import { getCurrentWebView } from '../browser-util';
 import { remote, clipboard, ipcRenderer } from '../../../shared/electron';
-import * as userAgent from '../lib/user-agent';
 
 const { Menu, MenuItem } = remote;
 
@@ -39,40 +38,8 @@ external actions.
 /**
  * Open the browser (hamburger) menu
  */
-export function menuBrowser(pageSessionId, dispatch) {
-  const menu = new Menu();
-
-  menu.append(new MenuItem({
-    label: 'New Tab',
-    click: () => dispatch(actions.createTab()),
-  }));
-
-  menu.append(new MenuItem({
-    label: 'New Window',
-    click: () => newBrowserWindow(),
-  }));
-
-  menu.append(new MenuItem({
-    label: 'Fetch page contents',
-    click: () => {
-      // @TODO all webview access must be handled via `webview-controller`
-      const webview = getCurrentWebView(document);
-      const script = 'window._readerify(window.document)';
-      webview.executeJavaScript(script, false, readerResult => {
-        if (!readerResult) {
-          return;
-        }
-
-        userAgent.createPage({
-          url: readerResult.uri,
-          session: pageSessionId,
-          page: readerResult,
-        });
-      });
-    },
-  }));
-
-  menu.popup(remote.getCurrentWindow());
+export function menuBrowser() {
+  ipcRenderer.send('open-menu');
 }
 
 /**

--- a/app/ui/browser/lib/webview-controller.js
+++ b/app/ui/browser/lib/webview-controller.js
@@ -71,6 +71,15 @@ class WebViewController extends EventEmitter {
     this.emit('navigate-refresh', pageId);
     this.emit(`navigate-refresh:${pageId}`, pageId);
   }
+
+  capturePage(pageId) {
+    const index = getPageIndexById(this.getPages(), pageId);
+    assert(index >= 0, `Page ${pageId} not found in current state.`);
+    assert(isUUID(pageId), `Invalid page id: ${pageId}`);
+
+    this.emit('capture-page', pageId);
+    this.emit(`capture-page:${pageId}`, pageId);
+  }
 }
 
 export default WebViewController;

--- a/app/ui/browser/views/browser.jsx
+++ b/app/ui/browser/views/browser.jsx
@@ -67,7 +67,7 @@ class BrowserWindow extends Component {
     const navRefresh = () => webViewController.navigateRefresh(currentPageId);
     const navigateTo = loc => webViewController.navigateTo(currentPageId, loc);
 
-    const openMenu = () => menuBrowser(currentPage.sessionId, dispatch);
+    const openMenu = () => menuBrowser();
     const isBookmarked = (url) => profile.bookmarks.has(url);
     const bookmark = (title, url) => {
       dispatch(actions.bookmark(currentPage.sessionId, url, title));
@@ -179,4 +179,7 @@ function attachIPCRendererListeners(browserView) {
   ipcRenderer.on('show-history', () => dispatch(actions.createTab('tofino://history')));
   ipcRenderer.on('focus-url-bar', () => {});
   ipcRenderer.on('open-bookmark', (_, bookmark) => dispatch(actions.createTab(bookmark.location)));
+
+  ipcRenderer.on('capture-page', () =>
+    webViewController.capturePage(browserView.props.currentPage.id));
 }

--- a/app/ui/browser/views/page/page.jsx
+++ b/app/ui/browser/views/page/page.jsx
@@ -56,6 +56,21 @@ class Page extends Component {
     webViewController.on(`navigate-to:${id}`,
       (_, loc) => webview.setAttribute('src', fixURL(loc)));
 
+    webViewController.on(`capture-page:${id}`, () => {
+      const script = 'window._readerify(window.document)';
+      webview.executeJavaScript(script, false, readerResult => {
+        if (!readerResult) {
+          return;
+        }
+
+        userAgent.createPage({
+          url: readerResult.uri,
+          session: page.sessionId,
+          page: readerResult,
+        });
+      });
+    });
+
     if (!page.guestInstanceId && page.location) {
       webview.setAttribute('src', fixURL(page.location));
     }


### PR DESCRIPTION
We cache the bookmarks data so we can rebuild the menu at any time and some
bits are moved around to allow for building menus for minimal OSX, regular
application and the hamburger menu. The hamburger menu has a slightly different
template allowing important options to be at the top level.

Fixes #305.