### PR TITLE
Make sure `npm run` doesn't start the build in development mode, Fixes #428

### DIFF
--- a/build/task-config-builder.js
+++ b/build/task-config-builder.js
@@ -10,7 +10,7 @@ import os from 'os';
 
 import * as BuildUtils from './utils';
 
-const BASE_CONFIG = {
+export const BASE_CONFIG = {
   // System information
   platform: os.platform(),
   arch: 'x64',
@@ -31,7 +31,7 @@ const BASE_CONFIG = {
 
   // The `development` option indicates whether or not the build is
   // using hot reloading and unminified content and other things like that.
-  development: true,
+  development: false,
 
   // Whether or not the build is packaged in an electron distributable
   packaged: false,

--- a/test/build/test-tasks.js
+++ b/test/build/test-tasks.js
@@ -8,8 +8,17 @@ import { autoFailingAsyncTest } from '../utils/async.js';
 import tasks from '../../build/tasks.js';
 import * as utils from '../../build/utils.js';
 import * as BuildConst from '../../build/const.js';
+import { BASE_CONFIG } from '../../build/task-config-builder.js';
+
+const currentExpectedConfig = Object.assign({}, BASE_CONFIG, {
+  test: true,
+});
 
 describe('build tasks', () => {
+  it('should have a proper `build-config.json` while testing', () => {
+    expect(utils.getBuildConfig()).toContain(currentExpectedConfig);
+  });
+
   it('should have a working `config` task', autoFailingAsyncTest(async function() {
     const initialConfig = utils.getBuildConfig();
     expect(initialConfig.foo).toNotExist();
@@ -18,10 +27,12 @@ describe('build tasks', () => {
 
     const loadedConfig = utils.getBuildConfig();
     expect(loadedConfig.foo).toBe('bar');
+    expect(loadedConfig).toContain(BASE_CONFIG);
 
     utils.writeBuildConfig(initialConfig);
     const reloadedConfig = utils.getBuildConfig();
     expect(reloadedConfig.foo).toNotExist();
+    expect(reloadedConfig).toContain(currentExpectedConfig);
   }));
 
   it('should have a working `clean` task', autoFailingAsyncTest(async function() {


### PR DESCRIPTION
Signed-off-by: Victor Porof <vporof@mozilla.com>

@jsantell Relevant discussion in https://github.com/mozilla/tofino/issues/428