### PR TITLE
Make it possible to skip building in appveyor like travis

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,9 @@ branches:
   only:
     - master
 
+skip_commits:
+  message: /\[ci skip\]/
+
 pull_requests:
   do_not_increment_build_number: true
 


### PR DESCRIPTION
Travis already skips builds with "[ci skip]" in a commit message by default, this makes appveyor do the same.