### PR TITLE
Avoid string concatenation in preload/content.js

### DIFF
--- a/app/content/preload/content.js
+++ b/app/content/preload/content.js
@@ -29,13 +29,16 @@ if (document.location.protocol === 'tofino:') {
       const args = [];
       args.push(`q=${encodeURIComponent(string)}`);
       if (since) {
-        args.push(`since=${encodeURIComponent('' + since)}`);
+        since = `${since}`;
+        args.push(`since=${encodeURIComponent(since)}`);
       }
       if (limit) {
-        args.push(`limit=${encodeURIComponent('' + limit)}`);
+        limit = `${limit}`;
+        args.push(`limit=${encodeURIComponent(limit)}`);
       }
       if (snippetSize) {
-        args.push(`snippetSize=${encodeURIComponent('' + snippetSize)}`);
+        snippetSize = `${snippetSize}`;
+        args.push(`snippetSize=${encodeURIComponent(snippetSize)}`);
       }
 
       return (await request(`/query?${args.join('&')}`)).results;


### PR DESCRIPTION
Signed-off-by: Victor Porof <vporof@mozilla.com>

Fixes https://github.com/mozilla/tofino/issues/456