### PR TITLE
Readd react-addons-test-utils that was removed in 82bc1bd2, since it'…

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "mocha-eslint": "2.0.2",
     "nyc": "6.4.0",
     "react-addons-perf": "15.0.1",
+    "react-addons-test-utils": "15.0.1",
     "require-dir": "^0.3.0",
     "rimraf": "2.5.2",
     "spectron": "2.37.0",

--- a/test/lint/test-packages.js
+++ b/test/lint/test-packages.js
@@ -35,6 +35,7 @@ const ignored = [
   'eslint-plugin-flow-vars',
   'eslint-plugin-import',
   'eslint-plugin-react',
+  'react-addons-test-utils',
 ];
 
 describe('packages', () => {


### PR DESCRIPTION
…s necessary for other React modules, and ignore it in the package linting. r=victorporof