### PR TITLE
Use default cursor for navbar and location bar

### DIFF
--- a/app/ui/browser/views/navbar/location.jsx
+++ b/app/ui/browser/views/navbar/location.jsx
@@ -44,6 +44,7 @@ const LOCATION_BAR_STYLE = Style.registerStyle({
   '@media (max-width: 1024px)': {
     margin: '12px 0',
   },
+  cursor: 'default',
 });
 
 const LOCATION_BAR_AUTOCOMPLETE_STYLE = Style.registerStyle({
@@ -55,6 +56,7 @@ const LOCATION_BAR_AUTOCOMPLETE_STYLE = Style.registerStyle({
   right: 0,
   top: '100%',
   zIndex: 2,
+  cursor: 'default',
 });
 
 const LOCATION_BAR_RESULTS_SNIPPET_STYLE = Style.registerStyle({

--- a/app/ui/browser/views/tabbar/tab.jsx
+++ b/app/ui/browser/views/tabbar/tab.jsx
@@ -27,6 +27,7 @@ const TAB_STYLE = Style.registerStyle({
     background: '#fff',
     color: '#555',
   },
+  cursor: 'default',
 });
 
 const TAB_TITLE_STYLE = Style.registerStyle({


### PR DESCRIPTION
The navbar, tab content, and autocomplete items all show the text cursor upon hover which seems weird -- no one is looking to copy that text.  Default cursor seems much more logical.