### PR TITLE
Add `npm run clobber` command to clear out built folders. r=Mossop

### DIFF
--- a/build/const.js
+++ b/build/const.js
@@ -2,3 +2,6 @@ import path from 'path';
 import * as BuildUtils from './utils';
 
 export const DIST_DIR = path.join(BuildUtils.getRoot(), 'dist');
+export const NODE_MODULES_DIR = path.join(BuildUtils.getRoot(), 'node_modules');
+export const BUILD_CONFIG_FILE = path.join(BuildUtils.getRoot(), 'build-config.json');
+export const ELECTRON_DIR = path.join(BuildUtils.getRoot(), '.electron');

--- a/build/main.js
+++ b/build/main.js
@@ -60,6 +60,7 @@ const handleDepsCheckSucceeded = () => {
     '--package': () => tasks.package(),
     '--test': args => tasks.test(args),
     '--lint': args => tasks.lintOnlyTest(args),
+    '--clobber': () => tasks.clobber(),
     '--build-deps': () => tasks.buildDeps(),
   };
   main(argv, tasks, handlers, handleTaskFailed);

--- a/build/task-clobber.js
+++ b/build/task-clobber.js
@@ -1,0 +1,9 @@
+
+import fs from 'fs-promise';
+import * as BuildConst from './const.js';
+
+export default async function(opts) {
+  await fs.remove(BuildConst.NODE_MODULES_DIR);
+  await fs.remove(BuildConst.ELECTRON_DIR);
+  await fs.remove(BuildConst.BUILD_CONFIG_FILE);
+}

--- a/build/tasks.js
+++ b/build/tasks.js
@@ -61,6 +61,10 @@ export default {
     await require('./task-test').default([...args, 'test/lint']);
   },
 
+  async clobber() {
+    await require('./task-clobber').default();
+  },
+
   async clean() {
     await require('./task-clean-package').default();
   },

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "package": "node build/main.js --package",
     "test": "nyc -s node build/main.js --test",
     "lint": "nyc node build/main.js --lint",
+    "clobber": "node build/main.js --clobber",
     "report": "nyc report",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "install": "node build/main.js --build-deps",


### PR DESCRIPTION
@Mossop what do you think?  The sad part here is you can't run clobber twice in a row because the second time the required modules to run the command are gone.  So not sure if we should go ahead and add this or just include instructions in the docs to manually remove the three folders for people having build problems.