### PR TITLE
Always launch a new process for the UA service.

### DIFF
--- a/app/main/browser-window.js
+++ b/app/main/browser-window.js
@@ -32,11 +32,11 @@ const browserWindows = [];
  * UA service is in its own process. Also takes an onload callback --
  * currently used for the first window created to record load times.
  */
-export async function createBrowserWindow(profileStoragePromise, onload) {
-  const profileStorage = await profileStoragePromise;
+export async function createBrowserWindow(userAgentPromise, onload) {
+  const userAgent = await userAgentPromise;
 
   // TODO: don't abuse the storage layer's session ID generation to produce scopes.
-  const scope = await profileStorage.startSession();
+  const scope = await userAgent.startSession();
 
   // Create the browser window.
   const browser = new BrowserWindow({

--- a/app/main/browser.js
+++ b/app/main/browser.js
@@ -38,16 +38,14 @@ import * as menu from './menu/index';
 import * as instrument from '../services/instrument';
 import registerAboutPages from './about-pages';
 import * as BW from './browser-window';
-import { ProfileStorage } from '../services/storage';
-import * as userAgentService from './user-agent-service';
-const profileStoragePromise = ProfileStorage.open(path.join(__dirname, '..', '..'));
+import userAgentClient from '../shared/user-agent-client';
 
-import WebSocket from 'ws';
 import * as endpoints from '../shared/constants/endpoints';
 
 const app = electron.app; // control application life.
 const ipc = electron.ipcMain;
 const globalShortcut = electron.globalShortcut;
+const userAgentPromise = userAgentClient.connect();
 
 const appStartupTime = Date.now();
 instrument.event('app', 'STARTUP');
@@ -64,7 +62,7 @@ app.on('ready', async function() {
   // Register `about:*` protocols after app's 'ready' event
   registerAboutPages();
 
-  await BW.createBrowserWindow(profileStoragePromise, () => {
+  await BW.createBrowserWindow(userAgentPromise, () => {
     instrument.event('browser', 'READY', 'ms', Date.now() - browserStartTime);
   });
 });
@@ -89,12 +87,12 @@ app.on('activate', async function() {
   // On OS X it's common to re-create a window in the app when the
   // dock icon is clicked and there are no other windows open.
   if (electron.BrowserWindow.getAllWindows().length === 0) {
-    await BW.createBrowserWindow(profileStoragePromise, () => menu.buildAppMenu(menuData));
+    await BW.createBrowserWindow(userAgentPromise, () => menu.buildAppMenu(menuData));
   }
 });
 
 ipc.on('new-browser-window', async function() {
-  await BW.createBrowserWindow(profileStoragePromise, () => menu.buildAppMenu(menuData));
+  await BW.createBrowserWindow(userAgentPromise, () => menu.buildAppMenu(menuData));
 });
 
 ipc.on('close-browser-window', BW.onlyWhenFromBrowserWindow(async function(bw) {
@@ -120,41 +118,18 @@ ipc.on('instrument-event', (event, args) => {
   instrument.event(args.name, args.method, args.label, args.value);
 });
 
-let ws = undefined;
-
 const menuData = {};
 
-profileStoragePromise.then(async function(profileStorage) {
-  const { reused } = await userAgentService.start(profileStorage,
-                                                  endpoints.UA_SERVICE_PORT,
-                                                  { debug: false, allowReuse: true });
-
-  if (reused) {
-    // In the future, let's do something like test a /status or /heartbeat endpoint for a version
-    // and well-known string to be sure that we're actually connecting to a UA service.
+userAgentPromise.then(async function(userAgent) {
+  if (userAgent.clientCount > 1) {
     console.log('Using an already running User Agent service ' +
-                `(running on ${endpoints.UA_SERVICE_PORT}).`);
+                `(running on ${endpoints.UA_SERVICE_PORT} with ` +
+                `${userAgent.clientCount} active clients).`);
   } else {
     console.log(`Started a new User Agent service (running on ${endpoints.UA_SERVICE_PORT}).`);
   }
 
-  ws = new WebSocket(`${endpoints.UA_SERVICE_WS}/diffs`);
-
-  ws.on('open', () => {
-    // Nothing for now.
-  });
-
-  ws.on('message', (data, flags) => {
-    // flags.binary will be set if a binary data is received.
-    // flags.masked will be set if the data was masked.
-    if (flags.binary) {
-      return;
-    }
-    const command = JSON.parse(data);
-    if (!command) {
-      return;
-    }
-
+  userAgent.on('diff', (command) => {
     if (command.type === 'initial') {
       menuData.recentBookmarks = command.payload.recentStars;
       menu.buildAppMenu(menuData);
@@ -166,4 +141,4 @@ profileStoragePromise.then(async function(profileStorage) {
       menu.buildAppMenu(menuData);
     }
   });
-});
+}, console.error);

--- a/app/shared/constants/endpoints.js
+++ b/app/shared/constants/endpoints.js
@@ -12,4 +12,4 @@
 
 export const UA_SERVICE_PORT = 9090;
 export const UA_SERVICE_HTTP = `http://localhost:${UA_SERVICE_PORT}/v1`;
-export const UA_SERVICE_WS = `ws://localhost:${UA_SERVICE_PORT}/v1`;
+export const UA_SERVICE_WS = `ws://localhost:${UA_SERVICE_PORT}/v1/ws`;

--- a/app/shared/user-agent-client.js
+++ b/app/shared/user-agent-client.js
@@ -1,0 +1,134 @@
+/*
+ Copyright 2016 Mozilla
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ this file except in compliance with the License. You may obtain a copy of the
+ License at http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software distributed
+ under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ specific language governing permissions and limitations under the License.
+ */
+
+import path from 'path';
+import EventEmitter from 'events';
+import WebSocket from 'ws';
+import request from 'request';
+import { setTimeout } from 'timers';
+import childProcess from 'child_process';
+import * as endpoints from './constants/endpoints';
+
+function uaRequest(service, options) {
+  return new Promise((resolve, reject) => {
+    request[options.method.toLowerCase()]({
+      url: `${endpoints.UA_SERVICE_HTTP}${service}`,
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+    }, (err, response, body) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+
+      resolve(JSON.parse(body));
+    });
+  });
+}
+
+class UserAgent extends EventEmitter {
+  constructor(ws, clientCount) {
+    super();
+
+    this.ws = ws;
+    this.clientCount = clientCount;
+
+    this.ws.on('message', (data) => {
+      data = JSON.parse(data);
+      const message = data.message;
+      delete data.message;
+      this.emit(message, data);
+    });
+  }
+
+  startSession() {
+    return uaRequest('/session/start', {
+      method: 'POST',
+    });
+  }
+}
+
+const timeout = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+
+function startService() {
+  // Start a UA service
+  const exec = 'node';
+  const args = ['server.js'];
+
+  console.log('Starting UA process');
+  childProcess.spawn(exec, args, {
+    detached: true,
+    cwd: path.join(__dirname, '..', 'main'),
+  });
+}
+
+function attemptConnect() {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(`${endpoints.UA_SERVICE_WS}`);
+
+    ws.on('open', () => {
+      console.log('Connected to UA process');
+
+      // The first message should be protocol information
+      ws.once('message', (data) => {
+        data = JSON.parse(data);
+
+        if (data.message !== 'protocol' || data.version !== 'v1') {
+          console.error(`Incorrect message ${JSON.stringify(data)}`);
+          reject();
+          return;
+        }
+        resolve(new UserAgent(ws, data.clientCount));
+      });
+    });
+
+    ws.on('error', (e) => {
+      reject(e);
+    });
+  });
+}
+
+async function backoffConnect() {
+  let timedout = false;
+  const timer = setTimeout(() => timedout = true, 5000);
+  let delay = 200;
+
+  while (!timedout) {
+    try {
+      const ua = await attemptConnect();
+      clearTimeout(timer);
+      return ua;
+    } catch (e) {
+      await timeout(delay);
+      delay *= 2;
+    }
+  }
+
+  throw new Error('Unable to connect to the UA service.');
+}
+
+export default {
+  async connect() {
+    console.log('Attempting to connect');
+    try {
+      return await attemptConnect();
+    } catch (e) {
+      if (e.code === 'ECONNREFUSED') {
+        startService();
+        return await backoffConnect();
+      }
+      throw e;
+    }
+  },
+};

--- a/build/task-run.js
+++ b/build/task-run.js
@@ -12,7 +12,7 @@ export default async function(args = []) {
 
   console.log(`Executing command: ${command}`);
 
-  await BuildUtils.spawn(command, [script, ...args], {
+  await BuildUtils.spawn(command, [script, '--enable-logging', ...args], {
     stdio: 'inherit',
   });
 }


### PR DESCRIPTION
This doesn't work yet (the UA service doesn't start up) but it should be pretty close. Basically we try to connect the websocket, if it fails we start a new service and connect again. The service closes itself once all clients have gone away.

Does this seem like it is along the right lines @ncalexan?

One issue is that there is a delay between starting the service and being able to connect. I almost want to make the main process listen for a connection from the service in that case.