### PR TITLE
Show and focus URL bar when creating a new tab.

### DIFF
--- a/app/content/preload/hover-status.js
+++ b/app/content/preload/hover-status.js
@@ -28,5 +28,5 @@ window.addEventListener('mouseover', e => {
     }
     el = el.parentNode;
   }
-  setStatus(false);
+  setStatus(null);
 });

--- a/app/ui/browser/constants/action-types.js
+++ b/app/ui/browser/constants/action-types.js
@@ -13,9 +13,9 @@ specific language governing permissions and limitations under the License.
 export const ATTACH_TAB = 'ATTACH_TAB';
 export const CLOSE_TAB = 'CLOSE_TAB';
 export const CREATE_TAB = 'CREATE_TAB';
-export const DUPLICATE_TAB = 'DUPLICATE_TAB';
 export const LOCATION_CHANGED = 'LOCATION_CHANGE';
 export const SET_USER_TYPED_LOCATION = 'SET_USER_TYPED_LOCATION';
+export const RESET_UI_STATE = 'RESET_UI_STATE';
 export const CLEAR_COMPLETIONS = 'CLEAR_COMPLETIONS';
 export const SET_URL_INPUT_VISIBLE = 'SET_URL_INPUT_VISIBLE';
 export const SET_URL_INPUT_FOCUSED = 'SET_URL_INPUT_FOCUSED';

--- a/app/ui/browser/model/index.js
+++ b/app/ui/browser/model/index.js
@@ -64,17 +64,17 @@ export const UIState = Immutable.Record({
   // The url of the currently hovered-over link
   statusText: null,
 
-  // What the user has typed into the location bar, stored by page id
+  // What the user has typed into the location bar, stored by page ID.
   userTypedLocation: Immutable.Map(),
 
   // Should the autocomplete popup be visible
   showCompletions: false,
 
-  // Should the URL input be visible (or the page title)
-  showURLBar: false,
+  // Should the URL input be visible (or the page title), stored by page ID.
+  showURLBar: Immutable.Map(),
 
-  // Is the URL input focused
-  focusedURLBar: false,
+  // Should the URL input be focused, stored by page ID.
+  focusedURLBar: Immutable.Map(),
 
   // Which autocomplete result is selected
   focusedResultIndex: -1,

--- a/app/ui/browser/model/index.js
+++ b/app/ui/browser/model/index.js
@@ -62,13 +62,13 @@ export const Profile = Immutable.Record({
  */
 export const UIState = Immutable.Record({
   // The url of the currently hovered-over link
-  statusText: false,
+  statusText: null,
 
   // What the user has typed into the location bar, stored by page id
   userTypedLocation: Immutable.Map(),
 
   // Should the autocomplete popup be visible
-  showCompletions: true,
+  showCompletions: false,
 
   // Should the URL input be visible (or the page title)
   showURLBar: false,

--- a/app/ui/browser/reducers/ui-state.js
+++ b/app/ui/browser/reducers/ui-state.js
@@ -10,35 +10,48 @@ CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 */
 
+import assert from 'assert';
 import 'babel-polyfill';
 
 import * as types from '../constants/action-types';
 import { UIState } from '../model';
+import { isUUID } from '../browser-util';
 
 const initialState = new UIState();
 
 export default function uiState(state = initialState, action) {
   switch (action.type) {
-    case types.SET_STATUS_TEXT:
-      return state.set('statusText', action.text);
-
+    // Per-Page state modifications first.  Eventually, we'll separate another reducer here.
     case types.LOCATION_CHANGED:
+      assert(isUUID(action.pageId), 'LOCATION_CHANGED requires a page id.');
       return state.setIn(['userTypedLocation', action.pageId], action.payload.text);
 
     case types.SET_USER_TYPED_LOCATION:
+      assert(isUUID(action.pageId), 'SET_USER_TYPED_LOCATION requires a page id.');
       return state.withMutations(mut => {
         mut.setIn(['userTypedLocation', action.pageId], action.payload.text);
         mut.set('showCompletions', true);
       });
 
-    case types.CLEAR_COMPLETIONS:
-      return state.set('showCompletions', false);
-
     case types.SET_URL_INPUT_VISIBLE:
-      return state.set('showURLBar', action.payload.visible);
+      assert(isUUID(action.pageId), 'SET_URL_INPUT_VISIBLE requires a page id.');
+      return state.setIn(['showURLBar', action.pageId], action.payload.visible);
 
     case types.SET_URL_INPUT_FOCUSED:
-      return state.set('focusedURLBar', action.payload.focused);
+      assert(isUUID(action.pageId), 'SET_URL_INPUT_FOCUSED requires a page id.');
+      return state.setIn(['focusedURLBar', action.pageId], action.payload.focused);
+
+    // Global state second.  The reset action might just return the blank `initialState` once we
+    // extract the per-Page reducer.  Until that time, we don't want to drop the per-Page details
+    // when we reset.
+    case types.RESET_UI_STATE:
+      return state.set('showCompletions', false);
+
+    case types.SET_STATUS_TEXT:
+      return state.set('statusText', action.text);
+
+    case types.CLEAR_COMPLETIONS:
+      return state.set('showCompletions', false);
 
     case types.SET_URL_INPUT_AUTOCOMPLETE_INDEX:
       return state.set('focusedResultIndex', action.payload.index);

--- a/app/ui/browser/selectors/index.js
+++ b/app/ui/browser/selectors/index.js
@@ -40,12 +40,12 @@ export function showCompletions(state) {
   return state.uiState.showCompletions;
 }
 
-export function focusedURLBar(state) {
-  return state.uiState.focusedURLBar;
+export function focusedURLBar(state, pageId) {
+  return !!state.uiState.focusedURLBar.get(pageId);
 }
 
-export function showURLBar(state) {
-  return state.uiState.showURLBar;
+export function showURLBar(state, pageId) {
+  return !!state.uiState.showURLBar.get(pageId);
 }
 
 export function focusedResultIndex(state) {

--- a/app/ui/browser/views/navbar/location.jsx
+++ b/app/ui/browser/views/navbar/location.jsx
@@ -406,7 +406,7 @@ Location.propTypes = {
   bookmark: PropTypes.func.isRequired,
   unbookmark: PropTypes.func.isRequired,
   navigateTo: PropTypes.func.isRequired,
-  userTypedLocation: PropTypes.string.isRequired,
+  userTypedLocation: PropTypes.string,
   showCompletions: PropTypes.bool.isRequired,
   showURLBar: PropTypes.bool.isRequired,
   focusedURLBar: PropTypes.bool.isRequired,

--- a/app/ui/browser/views/navbar/location.jsx
+++ b/app/ui/browser/views/navbar/location.jsx
@@ -120,7 +120,7 @@ export class Location extends Component {
   componentDidMount() {
     ipcRenderer.on('focus-url-bar', () => {
       this.refs.input.select();
-      this.props.dispatch(actions.setShowURLBar(true));
+      this.props.dispatch(actions.setShowURLBar(this.props.page.id, true));
     });
   }
 
@@ -208,21 +208,21 @@ export class Location extends Component {
   }
 
   handleTitleClick() {
-    this.props.dispatch(actions.setShowURLBar(true));
+    this.props.dispatch(actions.setShowURLBar(this.props.page.id, true));
   }
 
   handleTitleFocus() {
-    this.props.dispatch(actions.setShowURLBar(true));
+    this.props.dispatch(actions.setShowURLBar(this.props.page.id, true));
   }
 
   handleURLBarFocus() {
     this.refs.input.select();
-    this.props.dispatch(actions.setFocusedURLBar(true));
+    this.props.dispatch(actions.setFocusedURLBar(this.props.page.id, true));
   }
 
   handleURLBarBlur() {
-    this.props.dispatch(actions.setShowURLBar(false));
-    this.props.dispatch(actions.setFocusedURLBar(false));
+    this.props.dispatch(actions.setShowURLBar(this.props.page.id, false));
+    this.props.dispatch(actions.setFocusedURLBar(this.props.page.id, false));
   }
 
   handleURLBarKeyDown(ev, completionsForLocation) {
@@ -417,8 +417,8 @@ function mapStateToProps(state, ownProps) {
   return {
     userTypedLocation: selectors.getUserTypedLocation(state, ownProps.page.id),
     showCompletions: selectors.showCompletions(state),
-    showURLBar: selectors.showURLBar(state),
-    focusedURLBar: selectors.focusedURLBar(state),
+    showURLBar: selectors.showURLBar(state, ownProps.page.id),
+    focusedURLBar: selectors.focusedURLBar(state, ownProps.page.id),
     focusedResultIndex: selectors.focusedResultIndex(state),
   };
 }

--- a/app/ui/browser/views/page/page.jsx
+++ b/app/ui/browser/views/page/page.jsx
@@ -168,7 +168,7 @@ function addListenersToWebView(webview, pageAccessor, dispatch) {
       title,
     }));
 
-    dispatch(actions.setStatusText(false));
+    dispatch(actions.setStatusText(null));
 
     dispatch(actions.locationChanged(pageAccessor().id, {
       text: null,

--- a/app/ui/browser/views/page/status.jsx
+++ b/app/ui/browser/views/page/status.jsx
@@ -46,7 +46,7 @@ export function Status({ statusText }) {
 Status.displayName = 'Status';
 
 Status.propTypes = {
-  statusText: PropTypes.string.isRequired,
+  statusText: PropTypes.string,
 };
 
 function mapStateToProps(state) {

--- a/test/renderer/test-basic.renderer.js
+++ b/test/renderer/test-basic.renderer.js
@@ -21,7 +21,7 @@ describe('renderer - sanity checks', function() {
 
   it('renders basic components', function() {
     expect($('#browser-container')).toExist();
-    expect($('#browser-location-title-bar').hasAttribute('hidden')).toBe(false);
+    expect($('#browser-location-title-bar').hasAttribute('hidden')).toBe(true);
     expect($$('#browser-tabbar .tab').length).toBe(1);
     expect($$('webview').length).toBeGreaterThan(0);
   });

--- a/test/unit/ui/browser/actions/test-create-tab.js
+++ b/test/unit/ui/browser/actions/test-create-tab.js
@@ -18,6 +18,9 @@ describe('Action - CREATE_TAB', () => {
     this.store = configureStore();
     this.getPages = () => selectors.getPages(this.store.getState());
     this.getCurrentPageIndex = () => selectors.getCurrentPageIndex(this.store.getState());
+    this.getCurrentPageId = () => selectors.getCurrentPage(this.store.getState()).id;
+    this.showURLBar = (pageId) => selectors.showURLBar(this.store.getState(), pageId);
+    this.focusedURLBar = (pageId) => selectors.focusedURLBar(this.store.getState(), pageId);
     this.dispatch = this.store.dispatch;
   });
 
@@ -58,6 +61,49 @@ describe('Action - CREATE_TAB', () => {
     expect(getCurrentPageIndex()).toEqual(1,
                                           'CREATE_TAB updates `currentPageIndex` when creating a' +
                                           ' new tab with location');
+  });
+
+  it('Should create a new tab and focus it if selected', function() {
+    const { getCurrentPageIndex, getCurrentPageId, showURLBar, focusedURLBar, dispatch } = this;
+    dispatch(actions.createTab());
+    dispatch(actions.setShowURLBar(getCurrentPageId(), false));
+    dispatch(actions.setFocusedURLBar(getCurrentPageId(), false));
+
+    // Assert initial conditions.
+    expect(getCurrentPageIndex()).toEqual(0);
+    expect(showURLBar(getCurrentPageId())).toEqual(false);
+    expect(focusedURLBar(getCurrentPageId())).toEqual(false);
+
+    dispatch(actions.createTab('https://github.com/'));
+
+    expect(getCurrentPageIndex()).toEqual(
+      1,
+      'CREATE_TAB updates `currentPageIndex` when creating a new tab');
+    expect(showURLBar(getCurrentPageId())).toEqual(
+      true,
+      'CREATE_TAB does show URL bar when tab is selected');
+    expect(focusedURLBar(getCurrentPageId())).toEqual(
+      true,
+      'CREATE_TAB does focus URL bar when tab is selected');
+  });
+
+  it('Should create a new tab but not focus it if not selected', function() {
+    const { getCurrentPageIndex, getCurrentPageId, showURLBar, focusedURLBar, dispatch } = this;
+    dispatch(actions.createTab());
+    dispatch(actions.setShowURLBar(getCurrentPageId(), false));
+    dispatch(actions.setFocusedURLBar(getCurrentPageId(), false));
+
+    dispatch(actions.createTab('https://github.com/', undefined, { selected: false }));
+
+    expect(getCurrentPageIndex()).toEqual(
+      0,
+      'CREATE_TAB does not update `currentPageIndex` when creating a new tab but not selecting it');
+    expect(showURLBar(getCurrentPageId())).toEqual(
+      false,
+      'CREATE_TAB does not show URL bar when tab is not selected');
+    expect(focusedURLBar(getCurrentPageId())).toEqual(
+      false,
+      'CREATE_TAB does not focus URL bar when tab is not selected');
   });
 
   it('Should send a message to the main process', function() {


### PR DESCRIPTION
This also shows and focuses the URL bar when creating a new window,
since a new window immediately creates a new tab.

I elected to allow dispatching lists (Arrays) of actions to save renders
and set a pattern for avoiding races in the future.  In spirit, this is
similar to https://twitter.com/dan_abramov/status/656074974533459968 and
https://github.com/tshelburne/redux-batched-actions.  However, this
approach works with our thunk middleware (and those don't).