### PR TITLE
Separate Browser Toolbox from Developer Tools.

### DIFF
--- a/app/main/menu/menus.js
+++ b/app/main/menu/menus.js
@@ -77,6 +77,7 @@ const menus = {
     label: 'Tools',
     submenu: [
       items.reloadApp,
+      items.toggleBrowserToolbox,
       items.toggleDevTools,
     ],
   },

--- a/app/main/menu/submenu-items.js
+++ b/app/main/menu/submenu-items.js
@@ -144,9 +144,9 @@ items.reloadApp = {
   },
 };
 
-items.toggleDevTools = {
-  label: 'Toggle Developer Tools',
-  accelerator: (process.platform === 'darwin') ? 'Alt+Command+I' : 'Ctrl+Shift+I',
+items.toggleBrowserToolbox = {
+  label: 'Toggle Browser Toolbox',
+  accelerator: 'Alt+CmdOrCtrl+Shift+I',
   click(item, focusedWindow) {
     if (focusedWindow) {
       if (focusedWindow.isDevToolsOpened()) {
@@ -154,6 +154,16 @@ items.toggleDevTools = {
       } else {
         focusedWindow.openDevTools({ detach: true });
       }
+    }
+  },
+};
+
+items.toggleDevTools = {
+  label: 'Toggle Developer Tools',
+  accelerator: (process.platform === 'darwin') ? 'Alt+Command+I' : 'Ctrl+Shift+I',
+  click(item, focusedWindow) {
+    if (focusedWindow) {
+      focusedWindow.webContents.send('toggle-devtools');
     }
   },
 };

--- a/app/ui/browser/lib/webview-controller.js
+++ b/app/ui/browser/lib/webview-controller.js
@@ -80,6 +80,15 @@ class WebViewController extends EventEmitter {
     this.emit('capture-page', pageId);
     this.emit(`capture-page:${pageId}`, pageId);
   }
+
+  toggleDevtools(pageId) {
+    const index = getPageIndexById(this.getPages(), pageId);
+    assert(index >= 0, `Page ${pageId} not found in current state.`);
+    assert(isUUID(pageId), `Invalid page id: ${pageId}`);
+
+    this.emit('toggle-devtools', pageId);
+    this.emit(`toggle-devtools:${pageId}`, pageId);
+  }
 }
 
 export default WebViewController;

--- a/app/ui/browser/views/browser.jsx
+++ b/app/ui/browser/views/browser.jsx
@@ -167,4 +167,6 @@ function attachIPCRendererListeners(browserView) {
 
   ipcRenderer.on('capture-page', () =>
     webViewController.capturePage(browserView.props.currentPage.id));
+  ipcRenderer.on('toggle-devtools', () =>
+    webViewController.toggleDevtools(browserView.props.currentPage.id));
 }

--- a/app/ui/browser/views/page/page.jsx
+++ b/app/ui/browser/views/page/page.jsx
@@ -59,6 +59,15 @@ class Page extends Component {
     webViewController.on(`navigate-to:${id}`,
       (_, loc) => webview.setAttribute('src', fixURL(loc)));
 
+    webViewController.on(`toggle-devtools:${id}`, () => {
+      if (!webview.isDevToolsOpened()) {
+        // Per-WebView devtools are always detached, regardless of 'detached' and 'mode' options.
+        webview.openDevTools();
+      } else {
+        webview.closeDevTools();
+      }
+    });
+
     webViewController.on(`capture-page:${id}`, () => {
       const script = 'window._readerify(window.document)';
       webview.executeJavaScript(script, false, readerResult => {


### PR DESCRIPTION
@victorporof just the last commit.  Feel free to suggest better hotkeys, too -- no reason to vary from Firefox, I guess.

This should address the messaging around #350, although I agree that `Right Click > Inspect Element` is faster way to open the content devtools than the menu item.