### PR TITLE
Remove selector cruft from pages reducer. r=bgrins

### DIFF
--- a/app/ui/browser/reducers/pages.js
+++ b/app/ui/browser/reducers/pages.js
@@ -57,23 +57,6 @@ export default function basic(state = initialState, action) {
   }
 }
 
-export function getPages(state) {
-  return state.browserWindow.pages;
-}
-
-export function getCurrentPage(state) {
-  const index = getCurrentPageIndex(state);
-  return state.browserWindow.pages.get(index);
-}
-
-export function getCurrentPageIndex(state) {
-  return state.browserWindow.currentPageIndex;
-}
-
-export function getPageAreaVisible(state) {
-  return state.browserWindow.pageAreaVisible;
-}
-
 function createTab(state, location = HOME_PAGE, id = undefined, { selected = true }) {
   return state.withMutations(mut => {
     const page = new Page({ id, location });


### PR DESCRIPTION
These selectors were moved in c2150a2, but were reintroduced in a rebase.