### PR TITLE
Use Babel's transform-class-properties rule. r=vporof

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": [ "react" ],
-  "plugins": [ "transform-es2015-destructuring", "transform-es2015-parameters", "transform-es2015-modules-commonjs", "transform-async-to-generator", "transform-object-rest-spread" ],
+  "plugins": [ "transform-es2015-destructuring", "transform-es2015-parameters", "transform-es2015-modules-commonjs", "transform-async-to-generator", "transform-object-rest-spread", "transform-class-properties" ],
   "sourceMaps": "inline",
   "retainLines": true
 }

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "babel-core": "6.9.0",
     "babel-eslint": "6.0.4",
     "babel-plugin-transform-async-to-generator": "6.8.0",
+    "babel-plugin-transform-class-properties": "6.9.0",
     "babel-plugin-transform-es2015-destructuring": "6.9.0",
     "babel-plugin-transform-es2015-modules-commonjs": "6.8.0",
     "babel-plugin-transform-es2015-parameters": "6.9.0",

--- a/test/unit/lint/test-packages.js
+++ b/test/unit/lint/test-packages.js
@@ -29,6 +29,7 @@ const ignored = [
 
   // Modules used only for configuration.
   'babel-plugin-transform-async-to-generator',
+  'babel-plugin-transform-class-properties',
   'babel-plugin-transform-es2015-destructuring',
   'babel-plugin-transform-es2015-modules-commonjs',
   'babel-plugin-transform-es2015-parameters',


### PR DESCRIPTION
This enables us to declare and bind handlers in one go.

For example, the following code in [browser.jsx](https://github.com/mozilla/tofino/blob/master/app/ui/browser/views/browser.jsx#L35):

```
class BrowserWindow extends Component {
  constructor(props) {
    super(props);
    this.handleKeyDown = this.handleKeyDown.bind(this);
  }
  ...
  handleKeyDown(ev) {
    // function body here
  }
}
```

becomes:

```
class BrowserWindow extends Component {
  ...
  handleKeyDown = (ev) => {
    // function body here
  }
}
```

How would folks feel about that?