### PR TITLE
Make tofino work on windows again

### DIFF
--- a/app/main/spawn.js
+++ b/app/main/spawn.js
@@ -31,15 +31,12 @@ export function startUserAgentService() {
     '--content-service', endpoints.CONTENT_SERVER_ORIGIN,
   ], {
     detached: true,
-    stdio: ['ignore', process.stdout, process.stderr],
+    stdio: ['ignore'],
   });
 }
 
 export function startContentService() {
-  const child = spawn('node', [CONTENT_SERVICE_PATH], {
-    detached: true,
-    stdio: ['ignore', process.stdout, process.stderr],
-  });
+  const child = spawn('node', [CONTENT_SERVICE_PATH]);
 
   process.on('exit', () => {
     child.kill('SIGKILL');


### PR DESCRIPTION
For the UA service to be completely detached and outlive the parents on all platforms it can't share any stdio with the parent.

Apparently ignoring just stdin breaks process spawning on Windows.

Fixes #578