### PR TITLE
Turn off arrow-body-style so arrow functions can be wrapped in blocks if chosen

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -45,6 +45,7 @@
         "Immutable.Set"
       ]
     }],
+    "arrow-body-style": ["off"],
     "func-names": ["off"],
     "space-before-function-paren": ["error", "never"],
     "no-confusing-arrow": ["off"],


### PR DESCRIPTION
@jsantell, we talked about this a while ago.  Here's a PR