### PR TITLE
Looking for feedback: Disable logging for SET_STATUS_TEXT actions since they happen on every mousemove

### DIFF
--- a/app/ui/shared/configure-store.js
+++ b/app/ui/shared/configure-store.js
@@ -32,7 +32,11 @@ export default function(rootReducer, initialState) {
       duration: true,
       collapsed: true,
       predicate: (getState, action) => {
-        return typeof action !== 'function' && action.type !== types.SET_STATUS_TEXT;
+        if (action.type === types.SET_STATUS_TEXT) {
+          console.log(types.SET_STATUS_TEXT + " " + action.text);
+          return false;
+        }
+        return typeof action !== 'function';
       },
       stateTransformer: (state) => state.toJS(),
     }));

--- a/app/ui/shared/configure-store.js
+++ b/app/ui/shared/configure-store.js
@@ -12,6 +12,7 @@ specific language governing permissions and limitations under the License.
 
 import { applyMiddleware, createStore } from 'redux';
 import createLogger from 'redux-logger';
+import * as types from '../browser/constants/action-types';
 import thunk from './thunk';
 import * as instrument from './instrument';
 import BUILD_CONFIG from '../../../build-config';
@@ -30,7 +31,9 @@ export default function(rootReducer, initialState) {
     middleware.unshift(createLogger({
       duration: true,
       collapsed: true,
-      predicate: (getState, action) => typeof action !== 'function',
+      predicate: (getState, action) => {
+        return typeof action !== 'function' && action.type !== types.SET_STATUS_TEXT;
+      },
       stateTransformer: (state) => state.toJS(),
     }));
   }


### PR DESCRIPTION
Looking for feedback about this.  The console becomes very hard for me to scan because of the constant logging of the SET_STATUS_TEXT action (which happens whenever a link is hovered and then again when it's un-hovered).

I'd personally be fine with just not showing this action ever, even if that makes it a less correct action log and harder to debug SET_STATUS_TEXT calls.  That's what this PR does, but if others would rather keep it there I'm fine with closing.