### PR TITLE
Watch files for the browser, not content.  Fixes #613

### DIFF
--- a/build/tasks.js
+++ b/build/tasks.js
@@ -34,12 +34,12 @@ export default {
   },
 
   async run(args = []) {
-    this.build([...args, '--force']);
+    await this.build([...args, '--force']);
     await Lazy.run(args);
   },
 
   async runDev(args = []) {
-    this.build([...args, '--force'], { development: true });
+    await this.build([...args, '--force'], { development: true });
 
     const { buildFile, appDir } = require('./task-build-browser');
     const watcher = chokidar.watch(appDir, {
@@ -54,12 +54,12 @@ export default {
   },
 
   async test(args = []) {
-    this.build(args, { test: true });
+    await this.build(args, { test: true });
     await Lazy.test(args);
   },
 
   async package(args) {
-    this.build([...args, '--force'], { packaged: true });
+    await this.build([...args, '--force'], { packaged: true });
     await Lazy.clean();
     await Lazy.package();
   },

--- a/build/tasks.js
+++ b/build/tasks.js
@@ -41,7 +41,7 @@ export default {
   async runDev(args = []) {
     this.build([...args, '--force'], { development: true });
 
-    const { buildFile, appDir } = require('./task-build-content');
+    const { buildFile, appDir } = require('./task-build-browser');
     const watcher = chokidar.watch(appDir, {
       ignoreInitial: true,
     });


### PR DESCRIPTION
@victorporof @Mossop can one of you have a look?  The current code doesn't make sense to me since neither appDir or buildFile are exported from the build-content task, so I'm assuming this was an unintentional change