### PR TITLE
Fail tests when prop type validations fail

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,6 +5,9 @@
     },
     "development": {
       "presets": ["react"]
+    },
+    "test": {
+      "presets": ["react"]
     }
   },
   "plugins": [

--- a/app/ui/shared/configure-store.js
+++ b/app/ui/shared/configure-store.js
@@ -26,7 +26,7 @@ const instrumenter = _store => next => action => {
 export default function(rootReducer, initialState) {
   const middleware = [instrumenter, thunk];
 
-  if (BUILD_CONFIG.development) {
+  if (BUILD_CONFIG.development && !BUILD_CONFIG.test) {
     middleware.unshift(createLogger({
       duration: true,
       collapsed: true,

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "start": "cross-env NODE_ENV=\"production\" node build/main.js --run",
     "dev": "cross-env NODE_ENV=\"development\" node build/main.js --run-dev",
     "package": "cross-env NODE_ENV=\"production\" node build/main.js --package",
-    "test": "cross-env NODE_ENV=\"production\" nyc -s node build/main.js --test",
+    "test": "cross-env NODE_ENV=\"test\" nyc -s node build/main.js --test",
     "lint": "npm test test/unit/lint",
     "report": "nyc report",
     "coverage": "nyc report --reporter=text-lcov | coveralls",

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -4,5 +4,6 @@
 --check-leaks
 --full-trace
 --timeout 3000
+--require test/unit/head.js
 --require babel-polyfill
 --require isomorphic-fetch

--- a/test/unit/head.js
+++ b/test/unit/head.js
@@ -1,0 +1,13 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+/* eslint-disable no-console */
+
+// Make mocha tests fail if a prop type validation fails.
+const error = console.error;
+console.error = function(warning, ...args) {
+  if (/(Invalid prop|Failed propType)/.test(warning)) {
+    throw new Error(warning);
+  }
+  error.apply(console, [warning, ...args]);
+};

--- a/test/unit/ui/browser/views/developerbar/test-developerbar.js
+++ b/test/unit/ui/browser/views/developerbar/test-developerbar.js
@@ -11,7 +11,7 @@ import Btn from '../../../../../../app/ui/browser/widgets/btn';
 describe('components - DeveloperBar', () => {
   it('should not render when in production mode', () => {
     const wrapper = shallow(
-      <DeveloperBar />
+      <DeveloperBar buildConfig={{ development: false }} />
     );
     expect(wrapper.html()).toEqual(null);
   });

--- a/test/unit/ui/browser/views/navbar/test-location.js
+++ b/test/unit/ui/browser/views/navbar/test-location.js
@@ -20,13 +20,17 @@ function createSpyProps(store) {
     onLocationChange: expect.createSpy(),
     onLocationContextMenu: expect.createSpy(),
     onLocationReset: expect.createSpy(),
+    onClearCompletions: expect.createSpy(),
+    showURLBar: false,
+    focusedURLBar: false,
+    focusedResultIndex: 0,
     isBookmarked: expect.createSpy(),
     bookmark: expect.createSpy(),
     unbookmark: expect.createSpy(),
     ipcRenderer: Object.create(null),
     navigateTo: expect.createSpy(),
   };
-  props.pages = [props.page];
+  props.pages = Immutable.List([props.page]);
   return props;
 }
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/tofino/issues/35

This also makes test builds still compile in production mode but without babel-react-optimize.
Depends on https://github.com/mozilla/tofino/pull/617

Only commit a198e9d is relevant.

@jsantell 