### PR TITLE
Fix opening of a bookmark via menu. r=vporof

### DIFF
--- a/app/main/menu/submenu-items.js
+++ b/app/main/menu/submenu-items.js
@@ -129,7 +129,7 @@ items.openBookmark = (bookmark) => ({
   label: bookmark.title || bookmark.location,
   click(item, focusedWindow) {
     if (focusedWindow) {
-      focusedWindow.webContents.send('open-bookmark', bookmark.toJS());
+      focusedWindow.webContents.send('open-bookmark', bookmark);
     }
   },
 });


### PR DESCRIPTION
When clicking on a bookmark in the menu, we get an error, expecting immutable objects.

```
TypeError: bookmark.toJS is not a function
    at click (webpack:///./app/main/menu/submenu-items.js?:133:64)
    at MenuItem.click (/Users/jsantell/Dev/tofino/.electron/Electron.app/Contents/Resources/electron.asar/browser/api/menu-item.js:81:16)
    at Function.executeCommand (/Users/jsantell/Dev/tofino/.electron/Electron.app/Contents/Resources/electron.asar/browser/api/menu.js:119:40)
```