### PR TITLE
Do not lint dist/ directory, and move node_module ignoring to the .es…

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,5 @@
 lib/**
 pkg/**
+dist/**
+node_modules/**
 app/shared/preload/readability.js

--- a/test/unit/lint/test-eslint.js
+++ b/test/unit/lint/test-eslint.js
@@ -16,9 +16,6 @@ let paths = fs.readFileSync(path.join(__dirname, '..', '..', '..', '.eslintignor
 paths = paths.filter(i => i.length && !i.startsWith('#'))
              .map(i => i.startsWith('!') ? i.substr(1) : `!${i}`);
 
-// ESLint always ignores node_modules
-paths.unshift('!node_modules/**/*');
-
 // Prepend the full set of files
 paths.unshift(`**/${valid}`);
 


### PR DESCRIPTION
…lintignore file for consistency. r=vporof