### PR TITLE
Set ipcRenderer's max listeners to Infinity, rather than default 10, …

### DIFF
--- a/app/ui/browser/index.jsx
+++ b/app/ui/browser/index.jsx
@@ -94,3 +94,7 @@ userAgentClient.on('diff', (command) => {
 // then subsequently connect.
 ipcRenderer.on('user-agent-service-info', (_, { port, version, host }) =>
   userAgentClient.connect({ port, version, host }));
+
+// Set max listeners to Infinity, because each new tab will listen to more
+// events, and we'll intentionally go beyond the 10 listener default.
+ipcRenderer.setMaxListeners(Infinity);


### PR DESCRIPTION
…since listeners scale linearly to tab count. Fixes #633. r=vporof