### PR TITLE
Update electron to 1.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "repository": "https://github.com/mozilla/tofino",
   "_electron": {
     "mirror": "https://mozilla-releng-tofino.s3.amazonaws.com/mozilla/tofino-electron/",
-    "version": "1.2.1",
-    "revision": "ef9515aac9ea"
+    "version": "1.2.2",
+    "revision": "5cd1dc12f984"
   },
   "scripts": {
     "serve": "cross-env NODE_ENV=\"production\" node build/main.js --serve",


### PR DESCRIPTION
Signed-off-by: Victor Porof <vporof@mozilla.com>

@Mossop wanna do your magic?

Error: GET https://mozilla-releng-tofino.s3.amazonaws.com/mozilla/tofino-electron/ef9515aac9ea/electron-v1.2.2-darwin-x64.zip returned 403