### PR TITLE
Don't wait for stdout/stderr before exiting

### DIFF
--- a/build/main.js
+++ b/build/main.js
@@ -16,7 +16,6 @@
 require('babel-polyfill');
 require('babel-register')();
 
-const thenify = require('thenify-all').thenify;
 const semver = require('semver');
 const checkDependencies = require('check-dependencies');
 const VALID_NODE_VERSION_RANGE = require('../package.json').engines.node;
@@ -30,13 +29,7 @@ const handleDepsCheckFailed = result => {
 const handleTaskFailed = err => {
   console.error('Build failed.');
   console.error(err);
-
-  // Exitting immediately would stop the logging midway,
-  // resulting in incomplete output.
-  Promise.all([
-    thenify(process.stdout.once)('drain'),
-    thenify(process.stderr.once)('drain'),
-  ]).then(() => process.exit(1));
+  process.exit(1);
 };
 
 const checkNodeVersion = version => {

--- a/build/utils.js
+++ b/build/utils.js
@@ -135,6 +135,9 @@ export function webpackBuild(config) {
           errorDetails: true,
           chunkOrigins: true,
         });
+        // Rejecting immediately would result in garbled text if other
+        // logging operations follow. Furthermore, if the process exits,
+        // it will stop the logging midway, resulting in incomplete output.
         console.error(`\n${output}\n`);
         process.stderr.once('drain', () => reject('Compilation unsuccessful.'));
         return;


### PR DESCRIPTION
There is a race condition between when the process exits and when the stdout and stderr are drained. As a rule, process.exit() will always exit the process immediately, regardless of whether or not there's still something to be done, even like a console.log; furthermore, logging operations themselves aren't atomic, so performing multiple error logging operations consecutively might result in garbled output if they're not drained in succession. This patch only circumvents the issue, because since we drain the output in build/util.js/webpackBuild anyway, and that's the only place we expect rich long output, we can probably safely refrain from draining stdout and stderr at the top level as well.

EDIT:
So what ended up happening was that we were exiting normally, because a forced process.exit(1) wasn't being called since we were waiting for the output to drain.

Signed-off-by: Victor Porof <vporof@mozilla.com>

Should fix *some* of the issues in https://github.com/mozilla/tofino/issues/647