### PR TITLE
Remove dead code for production builds

### DIFF
--- a/build/config/webpack.base.snippets.prod.js
+++ b/build/config/webpack.base.snippets.prod.js
@@ -9,5 +9,10 @@ export default {
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': '"production"',
     }),
+    new webpack.optimize.UglifyJsPlugin({
+      compress: {
+        warnings: false,
+      },
+    }),
   ],
 };

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "semver": "5.1.1",
     "spectron": "3.2.3",
     "through2": "2.0.1",
+    "uglify-js": "github:mishoo/UglifyJS2#harmony",
     "tmp": "0.0.28",
     "vinyl-fs": "2.4.2",
     "webpack": "1.13.1",

--- a/test/unit/lint/test-packages.js
+++ b/test/unit/lint/test-packages.js
@@ -52,6 +52,7 @@ const ignored = [
   'babel-preset-react',
   'babel-runtime',
   'babel-eslint',
+  'uglify-js',
   'eslint',
   'eslint-config-airbnb',
   'eslint-plugin-flow-vars',


### PR DESCRIPTION
Fixes #524 

Unfortunately though, we can't turn this on at the moment because we compile to node 6, which supports a large set of the harmony features that we need. However, uglifyjs does not, but they're pretty close it seems. See https://github.com/mishoo/UglifyJS2/issues/448

I'll start filing issues in upstream for the things we run into.