### PR TITLE
Remove the `packaged` option from the build-config

### DIFF
--- a/build/base-config.js
+++ b/build/base-config.js
@@ -25,9 +25,6 @@ export default {
   // using hot reloading and unminified content and other things like that.
   development: false,
 
-  // Whether or not the build is packaged in an electron distributable
-  packaged: false,
-
   // Whether or not the build is being tested
   test: false,
 

--- a/build/tasks.js
+++ b/build/tasks.js
@@ -93,7 +93,7 @@ export default {
     // XXX: All builds (including packaged) currently start their own
     // UA and Contents services. In the future, we should consider
     // hosting these somewhere else other than the user's own machine.
-    await this.build({ packaged: true });
+    await this.build();
     await Lazy.clean();
     await Lazy.package();
   },


### PR DESCRIPTION
Signed-off-by: Victor Porof <vporof@mozilla.com>

It's not used anywhere.