### PR TITLE
Reuse existing builds when running tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
   - npm prune
 
 script:
-  - npm test
+  - npm run test-ci
 
 after_success:
   - npm run package

--- a/app/services/instrument.js
+++ b/app/services/instrument.js
@@ -7,8 +7,7 @@
 
 import { app } from 'electron';
 import request from 'request';
-
-import { googleAnalyticsTrackingID } from '../../build-config';
+import { GOOGLE_ANALYTICS_TRACKING_ID } from '../shared/constants/endpoints';
 
 /**
  * Send an instrumentation payload to Google Analytics.
@@ -22,7 +21,7 @@ function send(payload) {
     aip: 1, // Anonymize IP address.
     an: app.getName(),
     av: app.getVersion(),
-    tid: googleAnalyticsTrackingID,
+    tid: GOOGLE_ANALYTICS_TRACKING_ID,
     cid: 0xdeadbeef, // Anonymous client ID for now.  TODO: track this per profile.
   });
 

--- a/app/shared/constants/endpoints.js
+++ b/app/shared/constants/endpoints.js
@@ -26,3 +26,6 @@ export const CONTENT_SERVER_VERSION = 'v1';
 
 export const CONTENT_SERVER_ORIGIN = `http://${CONTENT_SERVER_ADDR}:${CONTENT_SERVER_PORT}`;
 export const CONTENT_SERVER_HTTP = `${CONTENT_SERVER_ORIGIN}/${CONTENT_SERVER_VERSION}`;
+
+// The Google Analytics tracking identifier to use when instrumenting.
+export const GOOGLE_ANALYTICS_TRACKING_ID = 'UA-76122102-1';

--- a/app/ui/browser/index.jsx
+++ b/app/ui/browser/index.jsx
@@ -32,7 +32,6 @@ import App from './views/app';
 import { createBrowserStore } from './store';
 import * as actions from './actions/main-actions';
 import * as profileDiffs from '../../shared/profile-diffs';
-import BUILD_CONFIG from '../../../build-config';
 import UserAgentClient from '../../shared/user-agent-client';
 
 const userAgentClient = new UserAgentClient();
@@ -50,7 +49,7 @@ const app = {
   store,
 };
 
-if (BUILD_CONFIG.test) {
+if (process.env.TEST) {
   window.app = app;
 
   // Make the store accessible from the ipcRenderer singleton

--- a/app/ui/shared/configure-store.js
+++ b/app/ui/shared/configure-store.js
@@ -39,7 +39,7 @@ export default function(rootReducer, initialState) {
   const middleware = [instrumenter, thunk];
   const historyStore = [];
 
-  if (BUILD_CONFIG.development && !BUILD_CONFIG.test) {
+  if (BUILD_CONFIG.development && !process.env.TEST) {
     middleware.unshift(createLogger({
       duration: true,
       collapsed: true,
@@ -48,7 +48,7 @@ export default function(rootReducer, initialState) {
     }));
   }
 
-  if (BUILD_CONFIG.test) {
+  if (process.env.TEST) {
     middleware.unshift(history(historyStore));
   }
 
@@ -56,7 +56,7 @@ export default function(rootReducer, initialState) {
 
   // Store action history on the exposed store
   // for tests
-  if (BUILD_CONFIG.test) {
+  if (process.env.TEST) {
     store.history = historyStore;
   }
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ install:
 build: off
 
 test_script:
-  - npm test
+  - npm run test-ci
   - npm run package
 
 before_deploy:

--- a/build/base-config.js
+++ b/build/base-config.js
@@ -15,12 +15,6 @@ export default {
   // Version number, with extra build numbers if in a CI environment
   version: BuildUtils.getAppVersion(),
 
-  // If this build occurred on Travis CI
-  travis: BuildUtils.IS_TRAVIS,
-
-  // If this build occurred on Appveyor
-  appveyor: BuildUtils.IS_APPVEYOR,
-
   // The `development` option indicates whether or not the build is
   // using hot reloading and unminified content and other things like that.
   development: false,

--- a/build/base-config.js
+++ b/build/base-config.js
@@ -18,7 +18,4 @@ export default {
   // The `development` option indicates whether or not the build is
   // using hot reloading and unminified content and other things like that.
   development: false,
-
-  // Whether or not the build is being tested
-  test: false,
 };

--- a/build/base-config.js
+++ b/build/base-config.js
@@ -21,7 +21,4 @@ export default {
 
   // Whether or not the build is being tested
   test: false,
-
-  // The Google Analytics tracking identifier to use when instrumenting.
-  googleAnalyticsTrackingID: 'UA-76122102-1',
 };

--- a/build/main.js
+++ b/build/main.js
@@ -62,6 +62,7 @@ const handleDepsCheckSucceeded = () => {
     '--run-dev': args => tasks.runDev(args),
     '--package': () => tasks.package(),
     '--test': args => tasks.test(args),
+    '--test-ci': args => tasks.testCI(args),
   };
   main(argv, tasks, handlers, handleTaskFailed);
 };

--- a/build/task-test.js
+++ b/build/task-test.js
@@ -16,8 +16,6 @@ const ELECTRON_MOCHA = path.join(__dirname, '..', 'node_modules', '.bin', 'elect
 const PATH_TO_ELECTRON_MOCHA_OPTS = path.join(__dirname, '..', 'test', 'renderer', 'mocha.opts');
 
 export default async function(args) {
-  logger.info(colors.green('Running tests...'));
-
   // If no arguments passed in, we must run all tests; both mocha
   // and electron-mocha.
   if (!args.length) {
@@ -26,8 +24,11 @@ export default async function(args) {
     // all tests in series, but reject if any suite fails after
     // we're done.
     const errors = [];
+    logger.info(colors.cyan('Running unit tests...'));
     await runMochaTests(DEFAULT_UNIT_TESTS).catch(e => errors.push(e));
+    logger.info(colors.cyan('Running renderer tests...'));
     await runRendererTests(DEFAULT_RENDERER_TESTS).catch(e => errors.push(e));
+    logger.info(colors.cyan('Running webdriver tests...'));
     await runMochaTests(DEFAULT_WEBDRIVER_TESTS).catch(e => errors.push(e));
     if (errors.length) {
       throw errors[0];
@@ -38,8 +39,10 @@ export default async function(args) {
     // globbing, but this is more than fine for now.
     const pathToTests = args[0];
     if (pathToTests.indexOf(path.join('test', 'renderer')) !== -1) {
+      logger.info(colors.cyan('Running renderer or webdriver tests...'));
       await runRendererTests(pathToTests);
     } else {
+      logger.info(colors.cyan('Running unit tests...'));
       await runMochaTests(pathToTests);
     }
   }

--- a/build/tasks.js
+++ b/build/tasks.js
@@ -94,6 +94,17 @@ export default {
     await Lazy.test(args);
   },
 
+  async testCI(args = []) {
+    // These tests run on the CI server.
+    logger.info('Making a production build...');
+    await this.build();
+    await Lazy.test(args);
+
+    logger.info('Making a development build...');
+    await this.build({ development: true });
+    await Lazy.test(args);
+  },
+
   async package() {
     // XXX: All builds (including packaged) currently start their own
     // UA and Contents services. In the future, we should consider

--- a/build/tasks.js
+++ b/build/tasks.js
@@ -85,7 +85,7 @@ export default {
   },
 
   async test(args = []) {
-    await this.build({ test: true });
+    await this.build();
     await Lazy.test(args);
   },
 

--- a/build/tasks.js
+++ b/build/tasks.js
@@ -2,6 +2,7 @@
 // http://creativecommons.org/publicdomain/zero/1.0/
 
 import colors from 'colors/safe';
+import * as BuildUtils from './utils';
 
 /**
  * Use need to allow lazy loading of modules for all tasks. Generally,
@@ -85,7 +86,11 @@ export default {
   },
 
   async test(args = []) {
-    await this.build();
+    // When testing locally, just use whatever build already existed,
+    // regardless of whether it's production or development.
+    const { development } = BuildUtils.safeGetBuildConfig();
+    logger.info(`Attempting to use existing ${development ? 'dev' : 'production'} build...`);
+    await this.build({ development });
     await Lazy.test(args);
   },
 

--- a/build/tasks.js
+++ b/build/tasks.js
@@ -5,7 +5,7 @@ import colors from 'colors/safe';
 
 /**
  * Use need to allow lazy loading of modules for all tasks. Generally,
- * we assume `build-config.js` exists, however *during* the build process
+ * we assume `build-config.json` exists, however *during* the build process
  * this might not be true, which will break certain native module imports that
  * try to eagerly load this file.
  */

--- a/build/utils.js
+++ b/build/utils.js
@@ -46,6 +46,14 @@ export function getRoot() {
   return path.dirname(__dirname);
 }
 
+export function safeGetBuildConfig() {
+  try {
+    return getBuildConfig();
+  } catch (e) {
+    return {};
+  }
+}
+
 export function getBuildConfig() {
   const file = path.join(__dirname, '..', 'build-config.json');
   return fs.readJsonSync(file);

--- a/build/webpack.config.base.js
+++ b/build/webpack.config.base.js
@@ -8,6 +8,7 @@ import * as BuildUtils from './utils';
 const root = BuildUtils.getRoot();
 
 export default {
+  output: {},
   module: {
     loaders: [{
       test: /\.jsx?$/,
@@ -29,4 +30,5 @@ export default {
     new webpack.OldWatchingPlugin(),
     new webpack.NoErrorsPlugin(),
   ],
+  externals: [],
 };

--- a/build/webpack.config.base.snippets.dev.js
+++ b/build/webpack.config.base.snippets.dev.js
@@ -10,9 +10,7 @@ export default {
   devtool: 'eval',
   plugins: [
     new webpack.DefinePlugin({
-      'process.env': {
-        NODE_ENV: '"development"',
-      },
+      'process.env.NODE_ENV': '"development"',
     }),
   ],
 };

--- a/build/webpack.config.base.snippets.dev.js
+++ b/build/webpack.config.base.snippets.dev.js
@@ -1,0 +1,18 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+import webpack from 'webpack';
+
+export default {
+  output: {
+    pathinfo: true,
+  },
+  devtool: 'eval',
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env': {
+        NODE_ENV: '"development"',
+      },
+    }),
+  ],
+};

--- a/build/webpack.config.base.snippets.prod.js
+++ b/build/webpack.config.base.snippets.prod.js
@@ -1,0 +1,15 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+import webpack from 'webpack';
+
+export default {
+  devtool: 'source-map',
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env': {
+        NODE_ENV: '"production"',
+      },
+    }),
+  ],
+};

--- a/build/webpack.config.base.snippets.prod.js
+++ b/build/webpack.config.base.snippets.prod.js
@@ -7,9 +7,7 @@ export default {
   devtool: 'source-map',
   plugins: [
     new webpack.DefinePlugin({
-      'process.env': {
-        NODE_ENV: '"production"',
-      },
+      'process.env.NODE_ENV': '"production"',
     }),
   ],
 };

--- a/build/webpack.config.browser.default.js
+++ b/build/webpack.config.browser.default.js
@@ -15,6 +15,7 @@ export default {
   ...defaultConfig,
   entry: path.join(SRC_DIR, 'index.jsx'),
   output: {
+    ...defaultConfig.output,
     path: DST_DIR,
     filename: 'index.js',
     sourceMapFilename: 'index.map',

--- a/build/webpack.config.browser.dev.js
+++ b/build/webpack.config.browser.dev.js
@@ -1,22 +1,18 @@
 // Any copyright is dedicated to the Public Domain.
 // http://creativecommons.org/publicdomain/zero/1.0/
 
-import webpack from 'webpack';
+import devConfig from './webpack.config.base.snippets.dev';
 import browserConfig from './webpack.config.browser.default';
 
 export default {
+  ...devConfig,
   ...browserConfig,
   output: {
+    ...devConfig.output,
     ...browserConfig.output,
-    pathinfo: true,
   },
-  devtool: 'eval',
   plugins: [
+    ...devConfig.plugins,
     ...browserConfig.plugins,
-    new webpack.DefinePlugin({
-      'process.env': {
-        NODE_ENV: JSON.stringify('development'),
-      },
-    }),
   ],
 };

--- a/build/webpack.config.browser.prod.js
+++ b/build/webpack.config.browser.prod.js
@@ -1,18 +1,14 @@
 // Any copyright is dedicated to the Public Domain.
 // http://creativecommons.org/publicdomain/zero/1.0/
 
-import webpack from 'webpack';
+import prodConfig from './webpack.config.base.snippets.prod';
 import browserConfig from './webpack.config.browser.default';
 
 export default {
+  ...prodConfig,
   ...browserConfig,
-  devtool: 'source-map',
   plugins: [
+    ...prodConfig.plugins,
     ...browserConfig.plugins,
-    new webpack.DefinePlugin({
-      'process.env': {
-        NODE_ENV: JSON.stringify('production'),
-      },
-    }),
   ],
 };

--- a/build/webpack.config.content-service.default.js
+++ b/build/webpack.config.content-service.default.js
@@ -14,6 +14,7 @@ export default {
   ...defaultConfig,
   entry: path.join(SRC_DIR, 'index.js'),
   output: {
+    ...defaultConfig.output,
     path: DST_DIR,
     filename: 'index.js',
     sourceMapFilename: 'index.map',
@@ -28,5 +29,8 @@ export default {
       LIBDIR: 'require("path").join(__dirname, "..", "..")',
     }),
   ],
-  externals: [nodeExternals()],
+  externals: [
+    ...defaultConfig.externals,
+    nodeExternals(),
+  ],
 };

--- a/build/webpack.config.content-service.dev.js
+++ b/build/webpack.config.content-service.dev.js
@@ -1,22 +1,18 @@
 // Any copyright is dedicated to the Public Domain.
 // http://creativecommons.org/publicdomain/zero/1.0/
 
-import webpack from 'webpack';
+import devConfig from './webpack.config.base.snippets.dev';
 import contentServiceConfig from './webpack.config.content-service.default';
 
 export default {
+  ...devConfig,
   ...contentServiceConfig,
   output: {
+    ...devConfig.output,
     ...contentServiceConfig.output,
-    pathinfo: true,
   },
-  devtool: 'eval',
   plugins: [
+    ...devConfig.plugins,
     ...contentServiceConfig.plugins,
-    new webpack.DefinePlugin({
-      'process.env': {
-        NODE_ENV: JSON.stringify('development'),
-      },
-    }),
   ],
 };

--- a/build/webpack.config.content-service.prod.js
+++ b/build/webpack.config.content-service.prod.js
@@ -1,18 +1,14 @@
 // Any copyright is dedicated to the Public Domain.
 // http://creativecommons.org/publicdomain/zero/1.0/
 
-import webpack from 'webpack';
+import prodConfig from './webpack.config.base.snippets.prod';
 import contentServiceConfig from './webpack.config.content-service.default';
 
 export default {
+  ...prodConfig,
   ...contentServiceConfig,
-  devtool: 'source-map',
   plugins: [
+    ...prodConfig.plugins,
     ...contentServiceConfig.plugins,
-    new webpack.DefinePlugin({
-      'process.env': {
-        NODE_ENV: JSON.stringify('production'),
-      },
-    }),
   ],
 };

--- a/build/webpack.config.content.default.js
+++ b/build/webpack.config.content.default.js
@@ -15,6 +15,7 @@ export default {
   ...defaultConfig,
   entry: path.join(SRC_DIR, 'index.jsx'),
   output: {
+    ...defaultConfig.output,
     path: DST_DIR,
     filename: 'index.js',
     sourceMapFilename: 'index.map',

--- a/build/webpack.config.content.dev.js
+++ b/build/webpack.config.content.dev.js
@@ -1,22 +1,18 @@
 // Any copyright is dedicated to the Public Domain.
 // http://creativecommons.org/publicdomain/zero/1.0/
 
-import webpack from 'webpack';
+import devConfig from './webpack.config.base.snippets.dev';
 import contentConfig from './webpack.config.content.default';
 
 export default {
+  ...devConfig,
   ...contentConfig,
   output: {
+    ...devConfig.output,
     ...contentConfig.output,
-    pathinfo: true,
   },
-  devtool: 'eval',
   plugins: [
+    ...devConfig.plugins,
     ...contentConfig.plugins,
-    new webpack.DefinePlugin({
-      'process.env': {
-        NODE_ENV: JSON.stringify('development'),
-      },
-    }),
   ],
 };

--- a/build/webpack.config.content.prod.js
+++ b/build/webpack.config.content.prod.js
@@ -1,18 +1,14 @@
 // Any copyright is dedicated to the Public Domain.
 // http://creativecommons.org/publicdomain/zero/1.0/
 
-import webpack from 'webpack';
+import prodConfig from './webpack.config.base.snippets.prod';
 import contentConfig from './webpack.config.content.default';
 
 export default {
+  ...prodConfig,
   ...contentConfig,
-  devtool: 'source-map',
   plugins: [
+    ...prodConfig.plugins,
     ...contentConfig.plugins,
-    new webpack.DefinePlugin({
-      'process.env': {
-        NODE_ENV: JSON.stringify('production'),
-      },
-    }),
   ],
 };

--- a/build/webpack.config.main.default.js
+++ b/build/webpack.config.main.default.js
@@ -14,6 +14,7 @@ export default {
   ...defaultConfig,
   entry: path.join(SRC_DIR, 'browser.js'),
   output: {
+    ...defaultConfig.output,
     path: DST_DIR,
     filename: 'index.js',
     sourceMapFilename: 'index.map',
@@ -31,5 +32,8 @@ export default {
       LIBDIR: 'require("path").join(__dirname, "..")',
     }),
   ],
-  externals: [nodeExternals()],
+  externals: [
+    ...defaultConfig.externals,
+    nodeExternals(),
+  ],
 };

--- a/build/webpack.config.main.dev.js
+++ b/build/webpack.config.main.dev.js
@@ -1,22 +1,18 @@
 // Any copyright is dedicated to the Public Domain.
 // http://creativecommons.org/publicdomain/zero/1.0/
 
-import webpack from 'webpack';
+import devConfig from './webpack.config.base.snippets.dev';
 import mainProcessConfig from './webpack.config.main.default';
 
 export default {
+  ...devConfig,
   ...mainProcessConfig,
   output: {
+    ...devConfig.output,
     ...mainProcessConfig.output,
-    pathinfo: true,
   },
-  devtool: 'eval',
   plugins: [
+    ...devConfig.plugins,
     ...mainProcessConfig.plugins,
-    new webpack.DefinePlugin({
-      'process.env': {
-        NODE_ENV: JSON.stringify('development'),
-      },
-    }),
   ],
 };

--- a/build/webpack.config.main.prod.js
+++ b/build/webpack.config.main.prod.js
@@ -1,18 +1,14 @@
 // Any copyright is dedicated to the Public Domain.
 // http://creativecommons.org/publicdomain/zero/1.0/
 
-import webpack from 'webpack';
+import prodConfig from './webpack.config.base.snippets.prod';
 import mainProcessConfig from './webpack.config.main.default';
 
 export default {
+  ...prodConfig,
   ...mainProcessConfig,
-  devtool: 'source-map',
   plugins: [
+    ...prodConfig.plugins,
     ...mainProcessConfig.plugins,
-    new webpack.DefinePlugin({
-      'process.env': {
-        NODE_ENV: JSON.stringify('production'),
-      },
-    }),
   ],
 };

--- a/build/webpack.config.ua-service.default.js
+++ b/build/webpack.config.ua-service.default.js
@@ -14,6 +14,7 @@ export default {
   ...defaultConfig,
   entry: path.join(SRC_DIR, 'bin', 'user-agent-service'),
   output: {
+    ...defaultConfig.output,
     path: DST_DIR,
     filename: 'user-agent-service',
     sourceMapFilename: 'user-agent-service.map',
@@ -28,5 +29,8 @@ export default {
       LIBDIR: 'require("path").join(__dirname, "..", "..")',
     }),
   ],
-  externals: [nodeExternals()],
+  externals: [
+    ...defaultConfig.externals,
+    nodeExternals(),
+  ],
 };

--- a/build/webpack.config.ua-service.dev.js
+++ b/build/webpack.config.ua-service.dev.js
@@ -1,22 +1,18 @@
 // Any copyright is dedicated to the Public Domain.
 // http://creativecommons.org/publicdomain/zero/1.0/
 
-import webpack from 'webpack';
+import devConfig from './webpack.config.base.snippets.dev';
 import uaServiceConfig from './webpack.config.ua-service.default';
 
 export default {
+  ...devConfig,
   ...uaServiceConfig,
   output: {
+    ...devConfig.output,
     ...uaServiceConfig.output,
-    pathinfo: true,
   },
-  devtool: 'eval',
   plugins: [
+    ...devConfig.plugins,
     ...uaServiceConfig.plugins,
-    new webpack.DefinePlugin({
-      'process.env': {
-        NODE_ENV: JSON.stringify('development'),
-      },
-    }),
   ],
 };

--- a/build/webpack.config.ua-service.prod.js
+++ b/build/webpack.config.ua-service.prod.js
@@ -1,18 +1,14 @@
 // Any copyright is dedicated to the Public Domain.
 // http://creativecommons.org/publicdomain/zero/1.0/
 
-import webpack from 'webpack';
+import prodConfig from './webpack.config.base.snippets.prod';
 import uaServiceConfig from './webpack.config.ua-service.default';
 
 export default {
+  ...prodConfig,
   ...uaServiceConfig,
-  devtool: 'source-map',
   plugins: [
+    ...prodConfig.plugins,
     ...uaServiceConfig.plugins,
-    new webpack.DefinePlugin({
-      'process.env': {
-        NODE_ENV: JSON.stringify('production'),
-      },
-    }),
   ],
 };

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "start": "cross-env NODE_ENV=\"production\" node build/main.js --run",
     "dev": "cross-env NODE_ENV=\"development\" node build/main.js --run-dev",
     "package": "cross-env NODE_ENV=\"production\" node build/main.js --package",
-    "test": "cross-env NODE_ENV=\"test\" nyc -s node build/main.js --test",
+    "test": "cross-env NODE_ENV=\"production\" TEST=true nyc -s node build/main.js --test",
     "lint": "npm test test/unit/lint",
     "report": "nyc report",
     "coverage": "nyc report --reporter=text-lcov | coveralls",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "dev": "node build/main.js --run-dev",
     "package": "node build/main.js --package",
     "test": "cross-env TEST=true nyc -s node build/main.js --test",
+    "test-ci": "cross-env TEST=true nyc -s node build/main.js --test-ci",
     "lint": "npm test test/unit/lint",
     "report": "nyc report",
     "coverage": "nyc report --reporter=text-lcov | coveralls",

--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
     "revision": "5cd1dc12f984"
   },
   "scripts": {
-    "serve": "cross-env NODE_ENV=\"production\" node build/main.js --serve",
-    "start": "cross-env NODE_ENV=\"production\" node build/main.js --run",
-    "dev": "cross-env NODE_ENV=\"development\" node build/main.js --run-dev",
-    "package": "cross-env NODE_ENV=\"production\" node build/main.js --package",
-    "test": "cross-env NODE_ENV=\"production\" TEST=true nyc -s node build/main.js --test",
+    "serve": "node build/main.js --serve",
+    "start": "node build/main.js --run",
+    "dev": "node build/main.js --run-dev",
+    "package": "node build/main.js --package",
+    "test": "cross-env TEST=true nyc -s node build/main.js --test",
     "lint": "npm test test/unit/lint",
     "report": "nyc report",
     "coverage": "nyc report --reporter=text-lcov | coveralls",

--- a/test/unit/build/test-tasks.js
+++ b/test/unit/build/test-tasks.js
@@ -3,6 +3,7 @@
 
 import expect from 'expect';
 import fs from 'fs-promise';
+import omit from 'lodash/omit';
 
 import { autoFailingAsyncTest } from '../../utils/async.js';
 import BASE_CONFIG from '../../../build/base-config.js';
@@ -12,8 +13,12 @@ import * as utils from '../../../build/utils.js';
 import * as BuildConst from '../../../build/const.js';
 
 describe('build tasks', () => {
+  // Tests might be running on both production and development builds, so
+  // there's no guarantee as to what `development` flag is set in the config.
+  const baseConfigToCheckAgainst = omit(BASE_CONFIG, 'development');
+
   it('should have a proper `build-config.json` while testing', () => {
-    expect(utils.getBuildConfig()).toContain(BASE_CONFIG);
+    expect(utils.getBuildConfig()).toContain(baseConfigToCheckAgainst);
   });
 
   it('should have a working `config` task', autoFailingAsyncTest(async function() {
@@ -24,12 +29,12 @@ describe('build tasks', () => {
 
     const loadedConfig = utils.getBuildConfig();
     expect(loadedConfig.foo).toBe('bar');
-    expect(loadedConfig).toContain(BASE_CONFIG);
+    expect(loadedConfig).toContain(baseConfigToCheckAgainst);
 
     utils.writeBuildConfig(initialConfig);
     const reloadedConfig = utils.getBuildConfig();
     expect(reloadedConfig.foo).toNotExist();
-    expect(reloadedConfig).toContain(BASE_CONFIG);
+    expect(reloadedConfig).toContain(baseConfigToCheckAgainst);
   }));
 
   it('should have a working `clean` task', autoFailingAsyncTest(async function() {

--- a/test/unit/build/test-tasks.js
+++ b/test/unit/build/test-tasks.js
@@ -11,13 +11,9 @@ import clean from '../../../build/task-clean-package.js';
 import * as utils from '../../../build/utils.js';
 import * as BuildConst from '../../../build/const.js';
 
-const currentExpectedConfig = Object.assign({}, BASE_CONFIG, {
-  test: true,
-});
-
 describe('build tasks', () => {
   it('should have a proper `build-config.json` while testing', () => {
-    expect(utils.getBuildConfig()).toContain(currentExpectedConfig);
+    expect(utils.getBuildConfig()).toContain(BASE_CONFIG);
   });
 
   it('should have a working `config` task', autoFailingAsyncTest(async function() {
@@ -33,7 +29,7 @@ describe('build tasks', () => {
     utils.writeBuildConfig(initialConfig);
     const reloadedConfig = utils.getBuildConfig();
     expect(reloadedConfig.foo).toNotExist();
-    expect(reloadedConfig).toContain(currentExpectedConfig);
+    expect(reloadedConfig).toContain(BASE_CONFIG);
   }));
 
   it('should have a working `clean` task', autoFailingAsyncTest(async function() {

--- a/test/webdriver/test-basic.js
+++ b/test/webdriver/test-basic.js
@@ -4,8 +4,16 @@
 import expect from 'expect';
 import Driver from '../utils/driver';
 import { HOME_PAGE } from '../../app/ui/browser/constants/ui';
+import BUILD_CONFIG from '../../build-config';
 
 describe('application launch', function() {
+  if (BUILD_CONFIG.development) {
+    // Skip test on development builds, since app.client returns the devtools
+    // window instead of the browser window, so all our checks are bogus.
+    // Should probably fix this.
+    return;
+  }
+
   this.timeout(Driver.TEST_TIMEOUT_IN_MS);
 
   beforeEach(async function() {


### PR DESCRIPTION
This PR does many things.

1. It tries to nuke as many things as possible out of build-config.json
2. It uses shared files for webpack development and production configurations
3. It relies on an environment variable for determining whether or not we're in a test environment
4. It makes `npm test` reuse whatever build was present, instead of enforcing a production build
5. It makes the CI run tests on both production and development builds

Reason why the `development` property is still in build-config.json, is that in tests we're sometimes importing app/ modules directly (and not running the tests against the js bundle created by webpack), a potential `GLOBAL_CONFIG` variable set by webpack would not exist.

@jsantell 