### PR TITLE
Add a stubbed out second frontend

### DIFF
--- a/app/main/browser-window.js
+++ b/app/main/browser-window.js
@@ -17,6 +17,8 @@ import * as hotkeys from './hotkeys';
 import { UI_DIR, fileUrl } from '../shared/paths-util';
 import BUILD_CONFIG from '../../build-config';
 
+// Switch 'browser' to 'browser-alt' to test second frontend.  We should have a flag
+// to the application to switch frontends
 const BROWSER_CHROME_URL = fileUrl(path.join(UI_DIR, 'browser', 'browser.html'));
 const BrowserWindow = electron.BrowserWindow;  // create native browser window.
 

--- a/app/ui/browser-alt/browser.html
+++ b/app/ui/browser-alt/browser.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <div id="browser-container">Nothing to see here</div>
+  </body>
+</html>

--- a/build/config/webpack.browseralt.default.js
+++ b/build/config/webpack.browseralt.default.js
@@ -1,0 +1,55 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+import path from 'path';
+import webpack from 'webpack';
+import CopyWebpackPlugin from 'copy-webpack-plugin';
+import defaultConfig from './webpack.base';
+import * as Const from '../utils/const';
+
+export const SHARED_DIR = path.join(Const.SRC_DIR, 'ui', 'shared');
+export const SRC_DIR = path.join(Const.SRC_DIR, 'ui', 'browser-alt');
+export const DST_DIR = path.join(Const.LIB_DIR, 'ui', 'browser-alt');
+
+export default {
+  ...defaultConfig,
+  entry: path.join(SRC_DIR, 'index.jsx'),
+  output: {
+    ...defaultConfig.output,
+    path: DST_DIR,
+    filename: 'index.js',
+    sourceMapFilename: 'index.map',
+  },
+  plugins: [
+    ...defaultConfig.plugins,
+    new webpack.DefinePlugin({
+      PROCESS_TYPE: '"ui"',
+    }),
+    new CopyWebpackPlugin([{
+      from: path.join(SRC_DIR, '*.html'),
+      to: DST_DIR,
+      flatten: true,
+    }]),
+    new CopyWebpackPlugin([{
+      from: path.join(SRC_DIR, 'css', '*.css'),
+      to: path.join(DST_DIR, 'css'),
+      flatten: true,
+    }]),
+    new CopyWebpackPlugin([{
+      from: path.join(SHARED_DIR, 'css', '*.css'),
+      to: path.join(DST_DIR, 'css'),
+      flatten: true,
+    }]),
+    new CopyWebpackPlugin([{
+      from: path.join(SHARED_DIR, 'assets'),
+      to: path.join(DST_DIR, 'assets'),
+      flatten: true,
+    }]),
+    new CopyWebpackPlugin([{
+      from: path.join(SHARED_DIR, 'fonts'),
+      to: path.join(DST_DIR, 'fonts'),
+      flatten: true,
+    }]),
+  ],
+  target: 'electron-renderer',
+};

--- a/build/config/webpack.browseralt.dev.js
+++ b/build/config/webpack.browseralt.dev.js
@@ -1,0 +1,18 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+import devConfig from './webpack.base.snippets.dev';
+import browserConfig from './webpack.browseralt.default';
+
+export default {
+  ...devConfig,
+  ...browserConfig,
+  output: {
+    ...devConfig.output,
+    ...browserConfig.output,
+  },
+  plugins: [
+    ...devConfig.plugins,
+    ...browserConfig.plugins,
+  ],
+};

--- a/build/config/webpack.browseralt.prod.js
+++ b/build/config/webpack.browseralt.prod.js
@@ -1,0 +1,14 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+import prodConfig from './webpack.base.snippets.prod';
+import browserConfig from './webpack.browseralt.default';
+
+export default {
+  ...prodConfig,
+  ...browserConfig,
+  plugins: [
+    ...prodConfig.plugins,
+    ...browserConfig.plugins,
+  ],
+};


### PR DESCRIPTION
This replaces #720.  We discussed landing a much smaller second frontend initially until there was a clearer decision on what we'd want to share.

@victorporof this is in much less risk of bitrotting, so lmk if you want to reduce duplication in build system here before landing, or if we should do it later.  I think one piece of low hanging fruit would be to have each webpack config file export dev and prod configs (so 1 file instead of 3).