### PR TITLE
Allow building packages from any branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ addons:
       secure: yOwR+kXPsGBRngo/WetjJoeHSgMwxnKXvQBj2+hj2CGSv3sInGWAxUvagG9uq8l6c9YruBYankljZtspbbgiHooyRATC4Bv2FEVEEZWQKipVt0s7yRvLH1EOLz2PZO61LNGQsrS8PwujO5F77kf4/HcOlxljk/O2gLtDiP9+4upHWcgOMOfvaOpMOc7t0cnTjyvhfcabHH3Pv56tWdJBvOhQAai+LAiUkdsmjH1fnAplxiYnTWbGVlsvr8bn1zqZNIx5ZnmxGjOiEVnZyLY3QfbyhsthGPiKKumMV7fgUYX79suM+rjLw7kDYn3q1kEGIPw88k7LYYzx/uftprAcfmScSns5G9uGThR+0jUvAL24zwaQh4USrLb8ru+OCt6N0/P/Pk/YlpVms27dl9DbopdOWARFLCwK/Sdwki2/g7u2VJv/BBCCYZ7G3te66rhy+o/UKBhb4UpjJGusbxwfHMu8v0tpwWsTQjX4XKbz8VvixkT//C+DrqFlJ6w04+ohW0hI4ejCoHRF7xEKgPZfnxEVtBYfvJSwgFky0bw3Dl1xuwWQ7KSLIu6VfSTDo7dU7TGYFOjJ/Gt6SsL7GKstp1pGO7lSyR5RyiQcaM1G08MmWNLwlcxgoaFMbmbAX01mItODlUTN8riW5lMixGxuJhFvpMGTKLBaz1gR04hJHVs=
     paths: $(cd dist && ls *.zip | tr "\n" ":")
     working_dir: dist
-    target_paths: mozilla/tofino/builds
+    target_paths: $(echo mozilla/tofino/builds/${TRAVIS_BRANCH})
     permissions: public-read
 
 before_install:
@@ -42,7 +42,3 @@ script:
 after_success:
   - npm run package
   - npm run coverage
-
-branches:
-  only:
-    - master

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,10 +7,6 @@ os: Previous Visual Studio 2015
 environment:
   nodejs_version: "6.1"
 
-branches:
-  only:
-    - master
-
 skip_commits:
   message: /\[ci skip\]/
 
@@ -46,4 +42,4 @@ deploy:
   bucket:
     secure: a/ijSslVXIxT1KRgwK6oWBJiOYD2DS5KCC5JpEDtXaU=
   set_public: true
-  folder: mozilla/tofino/builds
+  folder: mozilla/tofino/builds/$(appveyor_repo_branch)


### PR DESCRIPTION
Now we don't use branches in the main repository for personal work it makes sense to do CI builds and package uploads in all branches. This will move the location of the current builds.