### PR TITLE
Add a test to check licenses of all dependencies. r=mossop

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "glob": "7.0.5",
     "jsdom": "9.2.1",
     "json-loader": "0.5.4",
+    "license-checker": "5.1.2",
     "lodash": "4.13.1",
     "mocha": "2.5.3",
     "mocha-eslint": "2.1.1",
@@ -103,8 +104,8 @@
     "rimraf": "2.5.2",
     "semver": "5.1.1",
     "spectron": "3.2.3",
-    "uglify-js": "github:mishoo/UglifyJS2#harmony",
     "tmp": "0.0.28",
+    "uglify-js": "github:mishoo/UglifyJS2#harmony",
     "webpack": "1.13.1",
     "webpack-node-externals": "1.2.0",
     "zip-dir": "1.0.2"

--- a/test/unit/lint/test-licenses.js
+++ b/test/unit/lint/test-licenses.js
@@ -1,0 +1,96 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+import path from 'path';
+import expect from 'expect';
+import checker from 'license-checker';
+import { autoFailingAsyncTest } from '../../utils/async';
+const root = path.join(__dirname, '..', '..', '..');
+
+const WAIVED_DEPENDENCIES = [
+  // tweetnacl seems to be OK, in Public Domain
+  // https://github.com/dchest/tweetnacl-js/blob/master/COPYING.txt
+  'tweetnacl@0.14.3',
+];
+
+const VALID_LICENSES = [
+  'ISC',
+
+  'MIT',
+  'MIT*',
+  'MIT/X11',
+
+  'CC-BY-3.0',
+
+  'AFLv2.1',
+
+  'LGPL',
+  'GPLv2',
+  'GPLv3',
+
+  'MPLv2.0',
+
+  'Apache',
+  'Apache*',
+  'Apache2',
+  'Apache License, Version 2.0',
+  'Apache-2.0',
+
+  'BSD',
+  'BSD-2-Clause',
+  'BSD-3-Clause',
+  'BSD-like',
+  'BSD*',
+
+  'EPL',
+
+  'Artistic-2.0',
+
+  // Questionable licenses
+  'WTFPL',
+  'Unlicense',
+  'Public Domain',
+  'Public domain',
+];
+
+function isValidLicense(license) {
+  // If parentheses in string, like "(MIT OR BSD)", then just
+  // strip it out.
+  const matched = license.match(/^\((.*)\)$/);
+  if (matched && matched[1]) {
+    license = matched[1];
+  }
+
+  // Otherwise, apply the boolean logic of AND or OR'ing the licenses.
+  if (/ AND /.test(license)) {
+    return license.split(' AND ').every(l => VALID_LICENSES.includes(l));
+  } else if (/ OR /.test(license)) {
+    return license.split(' OR ').some(l => VALID_LICENSES.includes(l));
+  } else {
+    return VALID_LICENSES.includes(license);
+  }
+}
+
+describe('licenses', () => {
+  it('should be compatible licenses', autoFailingAsyncTest(async function() {
+    const licenseInfo = await new Promise(resolve => {
+      checker.init({
+        start: root,
+        depth: 'all',
+        include: 'all',
+      }, resolve);
+    });
+
+    const invalidDeps = Object.keys(licenseInfo).filter(dep => {
+      const licenses = licenseInfo[dep].licenses;
+      return !([].concat(licenses).every(isValidLicense));
+    }).filter(dep => {
+      return !WAIVED_DEPENDENCIES.includes(dep);
+    });
+
+    invalidDeps.forEach(dep => {
+      // Should change to fail test!
+      console.error(`Invalid license for ${dep}: ${licenseInfo[dep].licenses}`);
+    });
+  }));
+});


### PR DESCRIPTION
Right now this test just console.errors invalid licenses (which at the moment, is just UNKNOWN) -- how do the rest of the 'valid licenses' look?

This is our set of currently undefined licenses (and they may be valid, but should check each repo first)

Invalid license for assert-plus@0.1.5: UNKNOWN
Invalid license for buffers@0.1.1: UNKNOWN
Invalid license for commander@0.6.1: UNKNOWN
Invalid license for commander@2.3.0: UNKNOWN
Invalid license for debug@0.7.4: UNKNOWN
Invalid license for indexof@0.0.1: UNKNOWN
Invalid license for log-driver@1.2.4: UNKNOWN
Invalid license for options@0.0.6: UNKNOWN
Invalid license for precond@0.2.3: UNKNOWN
Invalid license for replaceall@0.1.6: UNKNOWN
Invalid license for ripemd160@0.2.0: UNKNOWN
Invalid license for single-line-log@0.4.1: UNKNOWN
Invalid license for tv4@1.2.7: UNKNOWN