### PR TITLE
Fixing activate for Mac OSX. Issue https://github.com/mozilla/tofino/issues/771

### DIFF
--- a/app/shared/user-agent-client.js
+++ b/app/shared/user-agent-client.js
@@ -91,6 +91,7 @@ class UserAgentClient extends EventEmitter {
           logger.error(`UserAgentClient: ${err}`);
         } else if (ws) {
           this.ws = ws;
+          this._connected = true;
           resolve(this);
         }
       });


### PR DESCRIPTION
[771](https://github.com/mozilla/tofino/issues/771)
https://github.com/mozilla/tofino/issues/771

Issue was that, during activation, the user-agent client was trying to connect, although there was an existing connection. Setting a connected flag to true, fixed this issue.