### PR TITLE
Block greenkeeper branches from building in CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ osx_image: xcode7.2
 sudo: required
 dist: trusty
 
+branches:
+  except:
+    - /^greenkeeper-.*$/
+
 cache:
   directories:
     - node_modules

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,10 @@ environment:
 skip_commits:
   message: /\[ci skip\]/
 
+branches:
+  except:
+    - /^greenkeeper-.*$/
+
 pull_requests:
   do_not_increment_build_number: true
 


### PR DESCRIPTION
This appears to work on both CI systems. I don't think it will block PRs from building since we used to restrict builds to only master and PRs still built then too.