### PR TITLE
Remove internal dependencies from sqlite.js.

### DIFF
--- a/app/services/places-import.js
+++ b/app/services/places-import.js
@@ -17,6 +17,8 @@ import {
 } from 'datascript-mori';
 import * as sqlite from './user-agent-service/sqlite';
 
+import { logger } from '../shared/logging';
+
 const d = datascript.core;
 
 const { vector, conj } = mori;
@@ -80,7 +82,7 @@ export class PlacesImporter {
 
   static async importFromPlaces(pathToPlaces, datomStorage, limit = undefined) {
     // The WAL is enabled, so opening read-only leaves orphaned .shm/.wal files.
-    const placesDB = await sqlite.DB.open(pathToPlaces);
+    const placesDB = await sqlite.DB.open(pathToPlaces, undefined, logger);
     try {
       const importer = new PlacesImporter(placesDB);
       await importer.buildPlaceMap(limit);

--- a/app/services/user-agent-service/sqlstorage.js
+++ b/app/services/user-agent-service/sqlstorage.js
@@ -25,6 +25,7 @@ import { Bookmark } from '../../shared/model';
 import { ProfileStorageSchemaV5 } from './profile-schema';
 import { DB, verbose } from './sqlite';
 import { SessionEndReason, SessionStartReason, SnippetSize, StarOp, VisitType } from './storage';
+import { logger } from '../../shared/logging';
 
 /**
  * Public API:
@@ -54,7 +55,7 @@ export class ProfileStorage {
     const filePath = path.join(dir, 'browser.db');
 
     await fs.mkdirp(dir);
-    const db = await DB.open(filePath);
+    const db = await DB.open(filePath, undefined, logger);
     return new ProfileStorage(db).init();
   }
 


### PR DESCRIPTION
This allows us to pull out sqlite.js as a separate library for use elsewhere.

Signed-off-by: Richard Newman <rnewman@twinql.com>