### PR TITLE
Use a less hacky hack for install npm dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,11 +50,9 @@ install:
   - nvm install 6.1
   - node --version
   - npm --version
-  - npm install --progress false --depth 0
   - npm prune
-  - cd node_modules/mv
-  - npm install rimraf@~2.4.0
-  - cd ../..
+  - npm install --progress false --depth 0
+  - npm install --progress false --depth 0
 
 script:
   - npm run test-ci

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,11 +24,9 @@ install:
   - node --version
   - npm --version
   - set npm_config_arch=%PLATFORM:x86=ia32%
-  - npm install --progress false --depth 0
   - npm prune
-  - cd node_modules\mv
-  - npm install rimraf@~2.4.0
-  - cd ..\..
+  - npm install --progress false --depth 0
+  - npm install --progress false --depth 0
 
 build: off
 


### PR DESCRIPTION
Running a second npm install fixes any dependencies missed from the first install attempt.