### PR TITLE
Mark dtrace-provider as an external that shouldn't be compiled into the UI package.

### DIFF
--- a/build/config/webpack.browser.default.js
+++ b/build/config/webpack.browser.default.js
@@ -54,6 +54,9 @@ const browserConfig = {
     }]),
   ],
   target: 'electron-renderer',
+  externals: [
+    'dtrace-provider',
+  ],
 };
 
 export const dev = {

--- a/build/config/webpack.browseralt.default.js
+++ b/build/config/webpack.browseralt.default.js
@@ -54,6 +54,9 @@ const browserConfig = {
     }]),
   ],
   target: 'electron-renderer',
+  externals: [
+    'dtrace-provider',
+  ],
 };
 
 export const dev = {


### PR DESCRIPTION
Fixes #688