### PR TITLE
Use a more fitting backdrop for page summary cards when a background image is supplied

### DIFF
--- a/app/ui/browser/views/overview/cards/base-card.jsx
+++ b/app/ui/browser/views/overview/cards/base-card.jsx
@@ -24,6 +24,15 @@ const CARD_STYLE = Style.registerStyle({
   cursor: 'pointer',
 });
 
+const BACKGROUND_STYLE = Style.registerStyle({
+  position: 'absolute',
+  top: 0,
+  bottom: 0,
+  left: 0,
+  right: 0,
+  zIndex: '-1',
+});
+
 const SUMMARY_STYLE = Style.registerStyle({
   background: 'var(--theme-overview-summary-background)',
   position: 'absolute',
@@ -39,7 +48,6 @@ const BaseCard = function(props) {
   return (
     <Thumbnail className={CARD_STYLE}
       style={{
-        backgroundColor: props.backgroundColor,
         borderColor: props.isSelected
           ? 'var(--theme-content-selected-border-color)'
           : 'var(--theme-content-border-color)',
@@ -53,6 +61,16 @@ const BaseCard = function(props) {
       imgMode="contain"
       imgPosition="top center"
       onClick={() => props.onClick(props.page.id)}>
+      <div className={BACKGROUND_STYLE}
+        style={props.backgroundImage ? {
+          backgroundImage: `url(${props.backgroundImage})`,
+          backgroundSize: '100% 100%',
+          WebkitFilter: 'brightness(5) blur(32px)',
+        } : {
+          backgroundColor: props.backgroundColor || 'transparent',
+          backgroundImage: 'url(assets/logo-tofino.png)',
+          backgroundSize: 'contain',
+        }} />
       <div className={SUMMARY_STYLE}>
         {props.children}
       </div>
@@ -65,8 +83,8 @@ BaseCard.displayName = 'BaseCard';
 BaseCard.propTypes = {
   page: SharedPropTypes.Page.isRequired,
   isSelected: PropTypes.bool.isRequired,
-  backgroundColor: PropTypes.string.isRequired,
-  backgroundImage: PropTypes.string.isRequired,
+  backgroundColor: PropTypes.string,
+  backgroundImage: PropTypes.string,
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node,

--- a/app/ui/browser/views/overview/cards/simple-card.jsx
+++ b/app/ui/browser/views/overview/cards/simple-card.jsx
@@ -11,29 +11,19 @@ specific language governing permissions and limitations under the License.
 */
 
 import React, { PropTypes } from 'react';
-import ColorScheme from 'color-scheme';
 
 import * as SharedPropTypes from '../../../../shared/model/shared-prop-types';
 import BaseCard from './base-card';
 import SimpleSummary from '../summaries/simple-summary';
 
-const DEFAULT_IMAGE = 'assets/logo-tofino.png';
-
-const COLORS = (new ColorScheme())
-  .from_hue(230)
-  .scheme('triade')
-  .variation('pastel')
-  .colors();
-
 const SimpleCard = function(props) {
   const meta = props.page.meta;
 
   const title = meta.title || props.page.title;
-  const backgroundImage = meta.image_url || DEFAULT_IMAGE;
+  const backgroundImage = meta.image_url;
 
   return (
     <BaseCard {...props}
-      backgroundColor={`#${COLORS[props.pageIndex % COLORS.length]}`}
       backgroundImage={backgroundImage}>
       <SimpleSummary title={title}
         url={props.page.location} />

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "backoff": "2.5.0",
     "body-parser": "1.15.2",
     "bunyan": "1.8.1",
-    "color-scheme": "0.0.5",
     "colors": "1.1.2",
     "datascript-mori": "0.16.0",
     "electron-localshortcut": "0.6.1",


### PR DESCRIPTION
Instead of using random colors:

![screen shot 2016-07-22 at 10 38 18 am](https://cloud.githubusercontent.com/assets/248899/17049864/70234e98-4ff8-11e6-9d67-bebf0593d794.png)

Signed-off-by: Victor Porof <vporof@mozilla.com>