### PR TITLE
Add favicons to overview cards. r=vporof

### DIFF
--- a/app/ui/browser/constants/ui.js
+++ b/app/ui/browser/constants/ui.js
@@ -24,9 +24,12 @@ export const NAVBAR_HORIZONTAL_PADDING = 10; // px
 export const OVERVIEWBAR_HEIGHT = NAVBAR_HEIGHT; // px
 export const OVERVIEWBAR_HORIZONTAL_PADDING = NAVBAR_HORIZONTAL_PADDING; // px
 
-// Overview (page summaries) dimensinos.
+// Overview (page summaries) dimensions.
 export const CARD_WIDTH = 140; // px
 export const CARD_HEIGHT = 175; // px
+// Overview (page summaries) favicon/badge dimensions.
+export const CARD_BADGE_WIDTH = 24; // px
+export const CARD_BADGE_HEIGHT = 24; // px
 
 // Show autocompletions when typing in location bar
 export const SHOW_COMPLETIONS = true;

--- a/app/ui/browser/views/overview/cards/base-card.jsx
+++ b/app/ui/browser/views/overview/cards/base-card.jsx
@@ -16,12 +16,19 @@ import * as SharedPropTypes from '../../../../shared/model/shared-prop-types';
 import * as UIConstants from '../../../constants/ui';
 import Style from '../../../../shared/style';
 import Thumbnail from '../../../../shared/widgets/thumbnail';
+import FittedImage from '../../../../shared/widgets/fitted-image';
 
 const CARD_STYLE = Style.registerStyle({
   WebkitUserSelect: 'none',
   position: 'relative',
   margin: '20px',
   cursor: 'pointer',
+});
+
+const BADGE_STYLE = Style.registerStyle({
+  top: 0,
+  left: 0,
+  position: 'absolute',
 });
 
 const BACKGROUND_STYLE = Style.registerStyle({
@@ -45,6 +52,9 @@ const SUMMARY_STYLE = Style.registerStyle({
 });
 
 const BaseCard = function(props) {
+  const backgroundImage = props.backgroundImage || props.page.meta.image_url;
+  const badgeImage = props.badgeImage || props.page.meta.icon_url;
+
   return (
     <Thumbnail className={CARD_STYLE}
       style={{
@@ -55,15 +65,20 @@ const BaseCard = function(props) {
           ? 'var(--theme-default-selected-shadow)'
           : 'var(--theme-default-shadow)',
       }}
-      src={props.backgroundImage}
+      src={backgroundImage}
       imgWidth={`${UIConstants.CARD_WIDTH}px`}
       imgHeight={`${UIConstants.CARD_HEIGHT}px`}
       imgMode="contain"
       imgPosition="top center"
       onClick={() => props.onClick(props.page.id)}>
+      <FittedImage className={BADGE_STYLE}
+        src={badgeImage}
+        width={`${UIConstants.CARD_BADGE_WIDTH}px`}
+        height={`${UIConstants.CARD_BADGE_HEIGHT}px`}
+        mode="contain" />
       <div className={BACKGROUND_STYLE}
-        style={props.backgroundImage ? {
-          backgroundImage: `url(${props.backgroundImage})`,
+        style={backgroundImage ? {
+          backgroundImage: `url(${backgroundImage})`,
           backgroundSize: '100% 100%',
           WebkitFilter: 'brightness(5) blur(32px)',
         } : {
@@ -85,6 +100,7 @@ BaseCard.propTypes = {
   isSelected: PropTypes.bool.isRequired,
   backgroundColor: PropTypes.string,
   backgroundImage: PropTypes.string,
+  badgeImage: PropTypes.string,
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node,

--- a/app/ui/browser/views/overview/cards/reviewable-card.jsx
+++ b/app/ui/browser/views/overview/cards/reviewable-card.jsx
@@ -23,7 +23,6 @@ const ReviewableCard = function(props) {
   const meta = props.page.meta;
 
   const title = meta.title || props.page.title;
-  const backgroundImage = meta.image_url;
 
   const reviewCount = parseInt(meta.review_count, 10);
   const rating = parseFloat(meta.rating, 10) || null;
@@ -31,8 +30,7 @@ const ReviewableCard = function(props) {
   const minRating = parseInt(meta.worst_rating || DEFAULT_MIN_RATING, 10) || null;
 
   return (
-    <BaseCard {...props}
-      backgroundImage={backgroundImage}>
+    <BaseCard {...props}>
       <ReviewableSummary title={title}
         reviewCount={reviewCount}
         rating={rating}

--- a/app/ui/browser/views/overview/cards/simple-card.jsx
+++ b/app/ui/browser/views/overview/cards/simple-card.jsx
@@ -20,11 +20,9 @@ const SimpleCard = function(props) {
   const meta = props.page.meta;
 
   const title = meta.title || props.page.title;
-  const backgroundImage = meta.image_url;
 
   return (
-    <BaseCard {...props}
-      backgroundImage={backgroundImage}>
+    <BaseCard {...props}>
       <SimpleSummary title={title}
         url={props.page.location} />
     </BaseCard>


### PR DESCRIPTION
<img width="991" alt="screen shot 2016-07-25 at 12 53 00 pm" src="https://cloud.githubusercontent.com/assets/641267/17115319/ad3f76d2-5267-11e6-81fc-09b131d1df87.png">

Doesn't yet work with Amazon (most things don't, metadata wise...) will handle in a follow up