### PR TITLE
Add price metadata to pages and display them alongside ratings and re…

### DIFF
--- a/app/ui/browser/model/index.js
+++ b/app/ui/browser/model/index.js
@@ -38,6 +38,8 @@ export const PageMeta = Immutable.Record({
   worst_rating: undefined,
   best_rating: undefined,
   review_count: undefined,
+  price: undefined,
+  currency: undefined,
 }, 'PageMeta');
 
 /**

--- a/app/ui/browser/views/overview/cards/overview-card.jsx
+++ b/app/ui/browser/views/overview/cards/overview-card.jsx
@@ -18,13 +18,13 @@ import React, { PropTypes } from 'react';
  */
 import * as SharedPropTypes from '../../../../shared/model/shared-prop-types';
 import SimpleCard from './simple-card';
-import ReviewableCard from './reviewable-card';
+import ProductCard from './product-card';
 
 const OverviewCard = function(props) {
   const meta = props.page.meta;
 
-  if (meta.rating) {
-    return (<ReviewableCard {...props} />);
+  if (meta.rating || meta.price) {
+    return (<ProductCard {...props} />);
   }
 
   return (<SimpleCard {...props} />);

--- a/app/ui/browser/views/overview/cards/product-card.jsx
+++ b/app/ui/browser/views/overview/cards/product-card.jsx
@@ -14,16 +14,44 @@ import React, { PropTypes } from 'react';
 
 import * as SharedPropTypes from '../../../../shared/model/shared-prop-types';
 import BaseCard from './base-card';
-import ReviewableSummary from '../summaries/reviewable-summary';
+import ProductSummary from '../summaries/product-summary';
 
 const DEFAULT_MAX_RATING = 5;
 const DEFAULT_MIN_RATING = 1;
 
-const ReviewableCard = function(props) {
+/**
+ * Takes a Page's meta object and determines how to format
+ * the price of a product on page.
+ */
+function getPrice(meta) {
+  if (meta.currency && meta.price) {
+    const formatted = (new Intl.NumberFormat(void 0, {
+      style: 'currency',
+      currency: meta.currency,
+    })).format(meta.price);
+
+    // It's possible for `price` to already include the currency symbol,
+    // like "$30.00", in which case, formatting it returns NaN; just return
+    // the price in that case, or for whatever other reason the value is
+    // improperly formatted.
+
+    // Number.isNaN doesn't work, but NaN does, since NumberFormat returns
+    // A STRING VERSION OF "NaN" IF IT FAILS. AHHHHHHHHHHH.
+    // And apparently `isNaN("$34.00") === true` so let's just use
+    // a string comparison because we can't have nice things.
+    return formatted === 'NaN' ? meta.price : formatted;
+  } else if (meta.price) {
+    return meta.price;
+  }
+  return void 0;
+}
+
+const ProductCard = function(props) {
   const meta = props.page.meta;
 
   const title = meta.title || props.page.title;
 
+  const price = getPrice(meta);
   const reviewCount = parseInt(meta.review_count, 10);
   const rating = parseFloat(meta.rating, 10) || null;
   const maxRating = parseInt(meta.best_rating || DEFAULT_MAX_RATING, 10) || null;
@@ -31,7 +59,8 @@ const ReviewableCard = function(props) {
 
   return (
     <BaseCard {...props}>
-      <ReviewableSummary title={title}
+      <ProductSummary title={title}
+        price={price}
         reviewCount={reviewCount}
         rating={rating}
         maxRating={maxRating}
@@ -40,13 +69,13 @@ const ReviewableCard = function(props) {
   );
 };
 
-ReviewableCard.displayName = 'ReviewableCard';
+ProductCard.displayName = 'ProductCard';
 
-ReviewableCard.propTypes = {
+ProductCard.propTypes = {
   page: SharedPropTypes.Page.isRequired,
   pageIndex: PropTypes.number.isRequired,
   isSelected: PropTypes.bool.isRequired,
   onClick: PropTypes.func.isRequired,
 };
 
-export default ReviewableCard;
+export default ProductCard;

--- a/app/ui/browser/views/overview/summaries/product-summary.jsx
+++ b/app/ui/browser/views/overview/summaries/product-summary.jsx
@@ -34,6 +34,15 @@ const TITLE_STYLE = Style.registerStyle({
   '-webkit-mask-image': GRADIENT_MASK,
 });
 
+const PRICE_STYLE = Style.registerStyle({
+  fontWeight: 'bold',
+  flexShrink: 0,
+  display: 'block',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+});
+
 const REVIEW_COUNT_STYLE = Style.registerStyle({
   flexShrink: 0,
   display: 'block',
@@ -44,25 +53,37 @@ const REVIEW_COUNT_STYLE = Style.registerStyle({
   color: 'var(--theme-overview-summary-subtitle-color)',
 });
 
-const ReviewableSummary = function(props) {
+const ProductSummary = function(props) {
+  const priceEl = props.price ? (
+    <div className={PRICE_STYLE}>
+      {props.price}
+    </div>
+  ) : void 0;
+
+  const reviewEl = props.reviewCount ? (
+    <div className={REVIEW_COUNT_STYLE}>
+      {`${props.reviewCount} reviews`}
+    </div>
+  ) : void 0;
+
   return (
     <div className={CONTAINER_STYLE}>
       <div className={TITLE_STYLE}>
         {props.title}
       </div>
+      {priceEl}
       <Ratings rating={props.rating}
         maxRating={props.maxRating}
         minRating={props.minRating} />
-      <div className={REVIEW_COUNT_STYLE}>
-        {`${props.reviewCount} reviews`}
-      </div>
+      {reviewEl}
     </div>
   );
 };
 
-ReviewableSummary.displayName = 'ReviewableSummary';
+ProductSummary.displayName = 'ProductSummary';
 
-ReviewableSummary.propTypes = {
+ProductSummary.propTypes = {
+  price: PropTypes.string,
   title: PropTypes.string.isRequired,
   reviewCount: PropTypes.number,
   rating: PropTypes.number,
@@ -70,4 +91,4 @@ ReviewableSummary.propTypes = {
   minRating: PropTypes.number,
 };
 
-export default ReviewableSummary;
+export default ProductSummary;

--- a/app/ui/preload/metadata-rules.js
+++ b/app/ui/preload/metadata-rules.js
@@ -106,6 +106,18 @@ const metadataRules = {
     // amazon
     ['#acrCustomerReviewText', parseIntText],
   ]),
+
+  price: buildRuleset('price', [
+    ['[itemprop="price"]', mapToContentOrText],
+    // amazon, on select "sale" items
+    ['#priceblock_dealprice', node => node.element.innerText],
+    // amazon
+    ['#priceblock_ourprice', node => node.element.innerText],
+  ]),
+
+  currency: buildRuleset('currency', [
+    ['[itemprop="priceCurrency"]', mapToContentOrText],
+  ]),
 };
 
 export default metadataRules;


### PR DESCRIPTION
…views as product cards. r=vporof

<img width="1265" alt="screen shot 2016-07-26 at 6 19 56 pm" src="https://cloud.githubusercontent.com/assets/641267/17162609/4ee4f516-536c-11e6-8206-440a74f7d067.png">
