### PR TITLE
Remove app icon path in main configuration for build due to change in…

### DIFF
--- a/build/task-package.js
+++ b/build/task-package.js
@@ -98,7 +98,6 @@ export default async function() {
         appId: 'tofino',
         'app-category-type': 'web',
         asar: true,
-        icon: Const.PACKAGED_ICON,
         ignore: IGNORE,
         electronVersion,
         download: downloadOptions,

--- a/build/utils/const.js
+++ b/build/utils/const.js
@@ -13,7 +13,6 @@ export const LIB_DIR = path.join(ROOT, 'lib');
 export const APP_SHARED_DIR = path.join(SRC_DIR, 'shared');
 
 export const PACKAGED_DIST_DIR = path.join(ROOT, 'dist');
-export const PACKAGED_ICON = path.join(ROOT, 'branding', 'app-icon');
 
 export const CACHE_DIR = path.join(ROOT, '.cache');
 export const ELECTRON_ROOT_DIR = path.join(ROOT, '.electron');


### PR DESCRIPTION
… electron-builder; linux now uses OSX icns anyway. r=mossop

Looks like this [patch changed](https://github.com/electron-userland/electron-builder/commit/ec0bda51732bc2331b257f1965bec009a85bb52b) it in electron-builder, and Linux will now use the `mac` object's icns now.