### PR TITLE
Disable the webdriver test on OSX.

### DIFF
--- a/test/webdriver/test-basic.js
+++ b/test/webdriver/test-basic.js
@@ -1,15 +1,17 @@
 // Any copyright is dedicated to the Public Domain.
 // http://creativecommons.org/publicdomain/zero/1.0/
 
+import os from 'os';
 import expect from 'expect';
 import Driver from '../utils/driver';
 import { HOME_PAGE } from '../../app/ui/browser/constants/ui';
 import BUILD_CONFIG from '../../build-config';
 
 describe('application launch', function() {
-  if (BUILD_CONFIG.development) {
+  if (BUILD_CONFIG.development || os.platform() === 'darwin') {
     // Skip test on development builds, since app.client returns the devtools
     // window instead of the browser window, so all our checks are bogus.
+    // Also skip on OSX where this test almost permafails.
     // Should probably fix this.
     return;
   }


### PR DESCRIPTION
This is basically permafailing so we might as well disable it on OSX.