### PR TITLE
Rebuild if the lib directory is missing

### DIFF
--- a/build/tasks.js
+++ b/build/tasks.js
@@ -4,6 +4,7 @@
 import colors from 'colors/safe';
 import { logger } from './logging';
 import { safeGetBuildConfig } from './utils';
+import { buildDirectoryExists, deleteBuildConfigHashes } from './utils/rebuild';
 import argv from './utils/argv';
 
 /**
@@ -39,6 +40,12 @@ const Tasks = {
 
   async build(config = {}, options = {}) {
     await Lazy.config(config);
+
+    // Check if the `lib` directory exists. If it doesn't, need to rebuild.
+    if (!(await buildDirectoryExists())) {
+      deleteBuildConfigHashes();
+    }
+
     const watchers = [];
     try {
       watchers.push(await Lazy.buildModules());
@@ -65,6 +72,7 @@ const Tasks = {
   async serve() {
     await Lazy.config();
     const watchers = [
+      await Lazy.buildModules(),
       await Lazy.buildContentService(),
       await Lazy.buildUserAgentService(),
     ];


### PR DESCRIPTION
Fixes https://github.com/mozilla/tofino/issues/1068

The problem was caused by the build-modules task, which always created a lib directory *before* we got a chance to test whether or not it was deleted.

Regressed by https://github.com/mozilla/tofino/commit/3d8d6314995d6a16442cc58d385f8509e6a97b6e

Signed-off-by: Victor Porof <vporof@mozilla.com>