### PR TITLE
Improve text legibility by using the default css text rendering

### DIFF
--- a/app/ui/shared/css/common.css
+++ b/app/ui/shared/css/common.css
@@ -6,7 +6,6 @@ body {
   margin: 0;
   /* Use a default system font in the entire application */
   font: 11px BlinkMacSystemFont, sans-serif;
-  text-rendering: geometricPrecision;
 }
 
 div {


### PR DESCRIPTION
This, combined with the new frontend look, should make all text legible.

Fixes https://github.com/mozilla/tofino/issues/836

Signed-off-by: Victor Porof <vporof@mozilla.com>