### PR TITLE
Properly handle the autocompletions list when switching tabs

### DIFF
--- a/app/ui/browser-modern/actions/profile-effects.js
+++ b/app/ui/browser-modern/actions/profile-effects.js
@@ -13,9 +13,10 @@ specific language governing permissions and limitations under the License.
 import * as EffectTypes from '../constants/effect-types';
 import * as PagesSelectors from '../selectors/pages';
 
-export function fetchLocationAutocompletions(text) {
+export function fetchLocationAutocompletions(pageId, text) {
   return {
     type: EffectTypes.FETCH_LOCATION_AUTOCOMPLETIONS,
+    pageId,
     text,
   };
 }

--- a/app/ui/browser-modern/actions/ui-actions.js
+++ b/app/ui/browser-modern/actions/ui-actions.js
@@ -47,9 +47,10 @@ export function hideOverview() {
   };
 }
 
-export function setLocationAutocompletions(autocompletions) {
+export function setLocationAutocompletions(pageId, autocompletions) {
   return {
     type: ActionTypes.SET_LOCATION_AUTOCOMPLETIONS,
+    pageId,
     autocompletions,
   };
 }

--- a/app/ui/browser-modern/model/ui.js
+++ b/app/ui/browser-modern/model/ui.js
@@ -16,5 +16,5 @@ export default Immutable.Record({
   statusText: '',
   pageSearchVisible: false,
   overviewVisible: false,
-  locationAutocompletions: Immutable.List(),
+  locationAutocompletions: Immutable.Map(),
 }, 'UIState');

--- a/app/ui/browser-modern/reducers/ui.js
+++ b/app/ui/browser-modern/reducers/ui.js
@@ -35,13 +35,14 @@ export default function(state = new UIState(), action) {
       return state;
 
     case ActionTypes.SET_LOCATION_AUTOCOMPLETIONS:
-      return setLocationAutocompletions(state, action.autocompletions);
+      return setLocationAutocompletions(state, action.pageId, action.autocompletions);
 
+    case ActionTypes.REMOVE_PAGE:
     case EffectTypes.NAVIGATE_PAGE_TO:
     case EffectTypes.NAVIGATE_PAGE_BACK:
     case EffectTypes.NAVIGATE_PAGE_FORWARD:
     case EffectTypes.NAVIGATE_PAGE_REFRESH:
-      return setLocationAutocompletions(state, []);
+      return setLocationAutocompletions(state, action.pageId, null);
 
     default:
       return state;
@@ -60,7 +61,10 @@ function setOverviewVisibility(state, visibility) {
   return state.set('overviewVisible', visibility);
 }
 
-function setLocationAutocompletions(state, autocompletions) {
+function setLocationAutocompletions(state, pageId, autocompletions) {
+  if (!autocompletions || !autocompletions.length) {
+    return state.deleteIn(['locationAutocompletions', pageId]);
+  }
   const records = autocompletions.map(e => new LocationAutocompletion(e));
-  return state.set('locationAutocompletions', Immutable.List(records));
+  return state.setIn(['locationAutocompletions', pageId], Immutable.List(records));
 }

--- a/app/ui/browser-modern/sagas/profile-sagas.js
+++ b/app/ui/browser-modern/sagas/profile-sagas.js
@@ -36,13 +36,13 @@ export default function() {
   ];
 }
 
-function* fetchCompletions({ text }) {
+function* fetchCompletions({ pageId, text }) {
   const autocompletions = [{ uri: text }];
   if (text) {
     const { results } = yield call(UserAgent.query, { text });
     autocompletions.push(...results);
   }
-  yield put(UIActions.setLocationAutocompletions(autocompletions));
+  yield put(UIActions.setLocationAutocompletions(pageId, autocompletions));
 }
 
 function* setRemoteBookmarkState({ page, bookmarked }) {

--- a/app/ui/browser-modern/selectors/ui.js
+++ b/app/ui/browser-modern/selectors/ui.js
@@ -22,6 +22,6 @@ export function getOverviewVisible(state) {
   return state.ui.overviewVisible;
 }
 
-export function getLocationAutocompletions(state) {
-  return state.ui.locationAutocompletions;
+export function getLocationAutocompletions(state, pageId) {
+  return state.ui.locationAutocompletions.get(pageId);
 }

--- a/app/ui/browser-modern/views/browser/location/index.jsx
+++ b/app/ui/browser-modern/views/browser/location/index.jsx
@@ -61,7 +61,9 @@ class Location extends Component {
   }
 
   handleInputChange = e => {
-    this.props.dispatch(ProfileEffects.fetchLocationAutocompletions(e.target.value));
+    const pageId = this.props.pageId;
+    const text = e.target.value;
+    this.props.dispatch(ProfileEffects.fetchLocationAutocompletions(pageId, text));
   }
 
   handleInputKeyDown = e => {
@@ -119,7 +121,7 @@ Location.propTypes = {
   pageId: PropTypes.string.isRequired,
   pageLocation: PropTypes.string.isRequired,
   pageIsBookmarked: PropTypes.bool.isRequired,
-  locationAutocompletions: SharedPropTypes.LocationAutocompletions.isRequired,
+  locationAutocompletions: SharedPropTypes.LocationAutocompletions,
   onNavigate: PropTypes.func.isRequired,
 };
 
@@ -128,7 +130,7 @@ function mapStateToProps(state, ownProps) {
   return {
     pageLocation: page ? page.location : '',
     pageIsBookmarked: page ? ProfileSelectors.isBookmarked(state, page.location) : false,
-    locationAutocompletions: UISelectors.getLocationAutocompletions(state),
+    locationAutocompletions: page ? UISelectors.getLocationAutocompletions(state, page.id) : null,
   };
 }
 

--- a/app/ui/shared/widgets/autocompleted-search.jsx
+++ b/app/ui/shared/widgets/autocompleted-search.jsx
@@ -48,10 +48,11 @@ class AutocompletedSearch extends Component {
   handleInputKeyDown = e => {
     const { showAutocompletions, selectedIndex } = this.state;
     const { autocompletionResults } = this.props;
+    const hasAutocompletionResults = autocompletionResults && autocompletionResults.size;
 
     switch (e.key) {
       case 'Enter': {
-        if (showAutocompletions && autocompletionResults.size) {
+        if (showAutocompletions && hasAutocompletionResults) {
           const data = this.props.autocompletionResults.get(this.state.selectedIndex);
           this.props.onAutocompletionSelect(data);
           // Don't call any `onKeyDown` event handler on a parent component.
@@ -69,7 +70,7 @@ class AutocompletedSearch extends Component {
         }
         break;
       case 'ArrowUp':
-        if (showAutocompletions && autocompletionResults.size) {
+        if (showAutocompletions && hasAutocompletionResults) {
           if (selectedIndex === 0) {
             this.setState({ selectedIndex: autocompletionResults.size - 1 });
           } else {
@@ -81,7 +82,7 @@ class AutocompletedSearch extends Component {
         break;
       case 'Tab':
       case 'ArrowDown':
-        if (showAutocompletions && autocompletionResults.size) {
+        if (showAutocompletions && hasAutocompletionResults) {
           if (selectedIndex === autocompletionResults.size - 1) {
             this.setState({ selectedIndex: 0 });
           } else {
@@ -121,6 +122,7 @@ class AutocompletedSearch extends Component {
   }
 
   render() {
+    const results = this.props.autocompletionResults;
     return (
       <div className={`widget-autocompleted-search ${AUTOCOMPLETED_SEARCH_STYLE}`}>
         <Search {...omit(this.props, Object.keys(AutocompletionProps))}
@@ -131,7 +133,7 @@ class AutocompletedSearch extends Component {
           selectedIndex={this.state.selectedIndex}
           onMouseOverChildComponent={this.handleMouseOverChildComponent}
           onClickOnChildComponent={this.handleClickOnChildComponent}>
-          {this.props.autocompletionResults.map(this.createAutocompletionListItem).toArray()}
+          {results && results.map(this.createAutocompletionListItem).toArray()}
         </AutocompletionList>
       </div>
     );
@@ -141,7 +143,7 @@ class AutocompletedSearch extends Component {
 AutocompletedSearch.displayName = 'AutocompletedSearch';
 
 const AutocompletionProps = {
-  autocompletionResults: ImmutablePropTypes.list.isRequired,
+  autocompletionResults: ImmutablePropTypes.list,
   autocompletionListItemComponent: PropTypes.func.isRequired,
   onAutocompletionSelect: PropTypes.func.isRequired,
 };


### PR DESCRIPTION
Fixes https://github.com/mozilla/tofino/issues/1087

Depends on https://github.com/mozilla/tofino/pull/1079

Signed-off-by: Victor Porof <vporof@mozilla.com>

This dependency graph might help: 
<img width="844" alt="screen shot 2016-09-12 at 12 40 55 pm" src="https://cloud.githubusercontent.com/assets/248899/18433181/83483a62-78e6-11e6-980d-d77c72e98953.png">