### PR TITLE
Use webview's `page-favicon-updated` for getting the favicon

### DIFF
--- a/app/ui/browser-modern/model/page-meta.js
+++ b/app/ui/browser-modern/model/page-meta.js
@@ -13,12 +13,19 @@ specific language governing permissions and limitations under the License.
 import Immutable from 'immutable';
 
 export default Immutable.Record({
-  description: undefined,
+  // Page data.
+  url: undefined,
+  title: undefined,
+
+  // Page media.
   icon_url: undefined,
   image_url: undefined,
-  title: undefined,
-  type: undefined,
-  url: undefined,
+
+  // Page info.
+  description: undefined,
+  keywords: undefined,
+
+  // Product pages properties.
   rating: undefined,
   worst_rating: undefined,
   best_rating: undefined,

--- a/app/ui/browser-modern/model/page.js
+++ b/app/ui/browser-modern/model/page.js
@@ -21,6 +21,7 @@ export default class Page extends Immutable.Record({
   id: undefined,
   location: '',
   title: '',
+  favicon_url: undefined,
   meta: new PageMeta(),
   state: new PageState(),
 }, 'Page') {

--- a/app/ui/browser-modern/reducers/pages.js
+++ b/app/ui/browser-modern/reducers/pages.js
@@ -119,7 +119,11 @@ function setPageDetails(state, pageId, pageDetails) {
 }
 
 function setPageMeta(state, pageId, pageMeta) {
-  return setPageDetails(state, pageId, { meta: new PageMeta(pageMeta) });
+  return state.withMutations(mut => {
+    for (const [key, value] of Object.entries(pageMeta)) {
+      mut.update('map', m => m.setIn([pageId, 'meta', key], value));
+    }
+  });
 }
 
 function setPageState(state, pageId, pageState) {

--- a/app/ui/browser-modern/reducers/pages.js
+++ b/app/ui/browser-modern/reducers/pages.js
@@ -16,6 +16,7 @@ import { logger } from '../../../shared/logging';
 import Page from '../model/page';
 import Pages from '../model/pages';
 import PageMeta from '../model/page-meta';
+import PageState from '../model/page-state';
 import * as UIConstants from '../constants/ui';
 import * as ActionTypes from '../constants/action-types';
 
@@ -121,6 +122,10 @@ function setPageDetails(state, pageId, pageDetails) {
 function setPageMeta(state, pageId, pageMeta) {
   return state.withMutations(mut => {
     for (const [key, value] of Object.entries(pageMeta)) {
+      if (!(key in PageMeta.prototype)) {
+        logger.warn(`Skipping setting of \`${key}\` on page meta.`);
+        continue;
+      }
       mut.update('map', m => m.setIn([pageId, 'meta', key], value));
     }
   });
@@ -129,6 +134,10 @@ function setPageMeta(state, pageId, pageMeta) {
 function setPageState(state, pageId, pageState) {
   return state.withMutations(mut => {
     for (const [key, value] of Object.entries(pageState)) {
+      if (!(key in PageState.prototype)) {
+        logger.warn(`Skipping setting of \`${key}\` on page state.`);
+        continue;
+      }
       mut.update('map', m => m.setIn([pageId, 'state', key], value));
     }
   });

--- a/app/ui/browser-modern/selectors/pages.js
+++ b/app/ui/browser-modern/selectors/pages.js
@@ -64,6 +64,10 @@ export function getSelectedPage(state) {
 
 // Page data getters.
 
+export function getPageMeta(state, id) {
+  return getPageById(state, id).meta;
+}
+
 export function getPageState(state, id) {
   return getPageById(state, id).state;
 }

--- a/app/ui/browser-modern/setup-ipc.js
+++ b/app/ui/browser-modern/setup-ipc.js
@@ -110,6 +110,18 @@ export default function({ store, userAgentClient }) {
     store.dispatch(PageEffects.performCurrentPageZoomReset());
   });
 
+  ipcRenderer.on('zoom-in', () => {
+    store.dispatch(PageEffects.performCurrentPageZoomIn());
+  });
+
+  ipcRenderer.on('zoom-out', () => {
+    store.dispatch(PageEffects.performCurrentPageZoomOut());
+  });
+
+  ipcRenderer.on('zoom-reset', () => {
+    store.dispatch(PageEffects.performCurrentPageZoomReset());
+  });
+
   ipcRenderer.on('show-stars', () => {
     store.dispatch(PageEffects.createPageSession(ContentURLs.STARS_PAGE));
   });

--- a/app/ui/browser-modern/views/browser/page/index.jsx
+++ b/app/ui/browser-modern/views/browser/page/index.jsx
@@ -117,6 +117,12 @@ class Page extends Component {
       this.props.dispatch(ProfileEffects.addRemoteHistory(this.props.pageId));
     });
 
+    this.webview.addEventListener('page-favicon-updated', e => {
+      this.props.dispatch(PageActions.setPageDetails(this.props.pageId, {
+        favicon_url: e.favicons[0],
+      }));
+    });
+
     this.webview.addEventListener('dom-ready', () => {
       this.props.dispatch(PageActions.setPageState(this.props.pageId, {
         canGoBack: this.webview.canGoBack(),

--- a/app/ui/browser-modern/views/browser/tabbar/tab.jsx
+++ b/app/ui/browser-modern/views/browser/tabbar/tab.jsx
@@ -153,7 +153,7 @@ function mapStateToProps(state, ownProps) {
   return {
     pageTitle: page ? page.title : '',
     pageLocation: page ? page.location : '',
-    pageFavicon: page ? page.meta.icon_url : '',
+    pageFavicon: page ? page.favicon_url : '',
     pageLoadState: page ? page.state.load : '',
     isActive: PagesSelectors.getSelectedPageId(state) === ownProps.pageId,
     isOverviewVisible: UISelectors.getOverviewVisible(state),

--- a/app/ui/preload/metadata-rules.js
+++ b/app/ui/preload/metadata-rules.js
@@ -53,19 +53,6 @@ const parseFloatText = node => parseFloat(node.element.innerText, 10);
  * in the page model in app/ui/browser-blueprint/model/index.js
  */
 const metadataRules = {
-  // Overwrite pmp's icon_url ruleset, and add a few more additional rules
-  icon_url: buildRuleset('icon_url', [
-    ['link[rel="apple-touch-icon"]', node => node.element.href],
-    ['link[rel="apple-touch-icon-precomposed"]', node => node.element.href],
-    ['link[rel="icon"]', node => node.element.href],
-    ['link[rel="fluid-icon"]', node => node.element.href],
-    ['link[rel="shortcut icon"]', node => node.element.href],
-    ['link[rel="Shortcut Icon"]', node => node.element.href],
-    ['link[rel="mask-icon"]', node => node.element.href],
-    // Fallback to just checking root favicon.ico
-    ['body', node => `${node.element.ownerDocument.location.origin}/favicon.ico`],
-  ]),
-
   // title takes some properties from page-metadata-parser,
   // and adds additional rules, like for Amazon.
   title: buildRuleset('title', [

--- a/app/ui/shared/widgets/overview/cards/base-card.jsx
+++ b/app/ui/shared/widgets/overview/cards/base-card.jsx
@@ -90,7 +90,7 @@ class BaseCard extends Component {
       badgeImage = TOFINO_LOGO;
     } else {
       backgroundImage = this.props.backgroundImage || this.props.page.meta.image_url;
-      badgeImage = this.props.badgeImage || this.props.page.meta.icon_url;
+      badgeImage = this.props.badgeImage || this.props.page.favicon_url;
     }
 
     return (


### PR DESCRIPTION
Fixes https://github.com/mozilla/tofino/issues/1098

Depends on https://github.com/mozilla/tofino/pull/1097

Signed-off-by: Victor Porof <vporof@mozilla.com>

This dependency graph might help: 
<img width="844" alt="screen shot 2016-09-12 at 12 40 55 pm" src="https://cloud.githubusercontent.com/assets/248899/18433181/83483a62-78e6-11e6-980d-d77c72e98953.png">