### PR TITLE
Optimistically set page location and update the urlbar before the navigation happens

### DIFF
--- a/app/ui/browser-modern/sagas/page-sagas.js
+++ b/app/ui/browser-modern/sagas/page-sagas.js
@@ -19,6 +19,7 @@ import * as UserAgent from '../../shared/util/user-agent';
 import * as PageActions from '../actions/page-actions';
 import * as PageEffects from '../actions/page-effects';
 import * as ProfileEffects from '../actions/profile-effects';
+import * as UIEffects from '../actions/ui-effects';
 import * as EffectTypes from '../constants/effect-types';
 
 export default function() {
@@ -74,6 +75,11 @@ function* destroyPageSession({ page, currentPageCount }) {
 function* naviatePageTo({ pageId, webview, location }) {
   yield put(PageActions.resetPageData(pageId));
   yield put(PageActions.setPageState(pageId, { load: PageState.STATES.PRE_LOADING }));
+  // Optimistically set page location and update the urlbar before the actual
+  // navigation happens, so that the UI shows the intended location instead of
+  // just some blank text.
+  yield put(PageActions.setPageDetails(pageId, { location }));
+  yield put(UIEffects.setURLBarValue(pageId, location));
   webview.setAttribute('src', location);
 }
 

--- a/app/ui/browser-modern/views/browser/tabbar/tab.jsx
+++ b/app/ui/browser-modern/views/browser/tabbar/tab.jsx
@@ -119,7 +119,7 @@ class Tab extends Component {
           )}
           <div className={`tab-title ${TAB_TITLE_STYLE}`}
             title={this.props.pageTitle}>
-            {this.props.pageTitle || this.props.pageLocation}
+            {this.props.pageTitle || this.props.pageLocation || 'Loading...'}
           </div>
           <Btn className="tab-close-button"
             title="Close tab"


### PR DESCRIPTION
Fixes https://github.com/mozilla/tofino/issues/1118

Doing this so that the UI shows the intended location instead of just some blank text. This could still happen though when clicking the back/forward buttons, since we don't know the location before the navigation happens; in those cases, just display 'Loading...'

Signed-off-by: Victor Porof <vporof@mozilla.com>