### PR TITLE
Add a badge displaying SSL status in the URL bar. Fixes #128. r=vporof

### DIFF
--- a/app/ui/browser-modern/views/browser/location/index.jsx
+++ b/app/ui/browser-modern/views/browser/location/index.jsx
@@ -16,6 +16,7 @@ import { connect } from 'react-redux';
 
 import Style from '../../../../shared/style';
 import Btn from '../../../../shared/widgets/btn';
+import SecurityBadge from './security-badge';
 import AutocompletedSearch from '../../../../shared/widgets/autocompleted-search';
 import AutocompletionListItem from './autocompletion-list-item';
 
@@ -80,6 +81,10 @@ class Location extends Component {
     // TODO
   }
 
+  handleConnectionButtonClick= () => {
+    // TODO
+  }
+
   handleBookmarkButtonClick = () => {
     const pageId = this.props.pageId;
     const bookmarked = this.props.pageIsBookmarked;
@@ -95,6 +100,12 @@ class Location extends Component {
           imgWidth="16px"
           imgHeight="16px"
           onClick={this.handleInfoButtonClick} />
+        <SecurityBadge title="Connection"
+          url={this.props.pageLocation}
+          pageState={this.props.pageState}
+          imgWidth="16px"
+          imgHeight="16px"
+          onClick={this.handleConnectionButtonClick} />
         <AutocompletedSearch ref={e => this.awesomebar = e}
           className={LOCATION_BAR_INPUT_STYLE}
           defaultValue={this.props.pageLocation}
@@ -121,6 +132,7 @@ Location.propTypes = {
   pageId: PropTypes.string.isRequired,
   pageLocation: PropTypes.string.isRequired,
   pageIsBookmarked: PropTypes.bool.isRequired,
+  pageState: SharedPropTypes.PageState,
   locationAutocompletions: SharedPropTypes.LocationAutocompletions,
   onNavigate: PropTypes.func.isRequired,
 };
@@ -129,6 +141,7 @@ function mapStateToProps(state, ownProps) {
   const page = PagesSelectors.getPageById(state, ownProps.pageId);
   return {
     pageLocation: page ? page.location : '',
+    pageState: PagesSelectors.getPageState(state, ownProps.pageId),
     pageIsBookmarked: page ? ProfileSelectors.isBookmarked(state, page.location) : false,
     locationAutocompletions: page ? UISelectors.getLocationAutocompletions(state, page.id) : null,
   };

--- a/app/ui/browser-modern/views/browser/location/security-badge.jsx
+++ b/app/ui/browser-modern/views/browser/location/security-badge.jsx
@@ -1,0 +1,78 @@
+/*
+Copyright 2016 Mozilla
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License. You may obtain a copy of the
+License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/
+
+import React, { Component, PropTypes } from 'react';
+import PureRenderMixin from 'react-addons-pure-render-mixin';
+import omit from 'lodash/omit';
+
+import * as SharedPropTypes from '../../../model/shared-prop-types';
+import PageStateModel from '../../../model/page-state';
+import Btn from '../../../../shared/widgets/btn';
+
+class SecurityBadge extends Component {
+  defaultProps: {
+    url: '',
+    hidden: false,
+  }
+
+  constructor(props) {
+    super(props);
+    this.shouldComponentUpdate = PureRenderMixin.shouldComponentUpdate.bind(this);
+  }
+
+  render() {
+    // Since we have unconfigurable security settings, if we access an HTTPS page and it loads,
+    // it is considered secure. Otherwise, all HTTP pages are insecure. Also, since
+    // we block all mixed content, this is even easier.
+    let image = 'ssl-insecure.svg';
+    if (/^https:/.test(this.props.url) && !this.props.pageState.error) {
+      image = 'ssl-secure.svg';
+    }
+
+    // If we have a tofino:// page, if the URL is empty (occurs during
+    // some page loads in our state), or if the page is still loading (many sites
+    // use http -> https redirects, we shouldn't penalize them for a quick interstitial),
+    // just hide the icon
+    let hidden = this.props.hidden;
+    if (!this.props.url ||
+        this.props.pageState.load === PageStateModel.STATES.PRE_LOADING ||
+        this.props.pageState.load === PageStateModel.STATES.LOADING ||
+        /^tofino:/.test(this.props.url)) {
+      hidden = true;
+    }
+
+    return (
+      <Btn {...omit(this.props, Object.keys(OmittedContainerProps))}
+        image={image}
+        hidden={hidden}>
+        {React.Children.toArray(this.props.children)}
+      </Btn>
+    );
+  }
+}
+
+SecurityBadge.displayName = 'SecurityBadge';
+
+const OmittedContainerProps = {
+  url: PropTypes.string.isRequired,
+  image: PropTypes.string,
+  hidden: PropTypes.bool,
+  pageState: SharedPropTypes.PageState.isRequired,
+};
+
+SecurityBadge.propTypes = {
+  ...omit(Btn.propTypes, Object.keys(OmittedContainerProps)),
+  url: OmittedContainerProps.url,
+  pageState: OmittedContainerProps.pageState,
+};
+
+export default SecurityBadge;

--- a/app/ui/shared/assets/ssl-insecure.svg
+++ b/app/ui/shared/assets/ssl-insecure.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+     width="16" height="16" viewBox="0 0 16 16">
+  <style>
+    .icon-default {
+      fill: #999;
+    }
+  </style>
+
+  <defs>
+    <rect id="shape-lock-clasp-outer" x="4" y="2" width="8" height="10" rx="4" ry="4" />
+    <rect id="shape-lock-clasp-inner" x="6" y="4" width="4" height="6" rx="2" ry="2" />
+    <rect id="shape-lock-base" x="3" y="7" width="10" height="7" rx="1" ry="1" />
+
+    <mask id="mask-clasp-cutout">
+      <rect width="16" height="16" fill="#000" />
+      <use xlink:href="#shape-lock-clasp-outer" fill="#fff" />
+      <use xlink:href="#shape-lock-clasp-inner" fill="#000" />
+      <line x1="2" y1="13" x2="14" y2="1.5" stroke="#000" stroke-width="2" />
+      <line x1="2" y1="15" x2="14" y2="3.5" stroke="#000" stroke-width="2" />
+      <rect x="3" y="7" width="10" height="7" rx="1" ry="1" fill="#000" />
+    </mask>
+
+    <mask id="mask-base-cutout">
+      <rect width="16" height="16" fill="#000" />
+      <use xlink:href="#shape-lock-base" fill="#fff" />
+      <line x1="2" y1="14.8" x2="14" y2="3.2" stroke="#000" stroke-width="1.8" />
+    </mask>
+  </defs>
+
+  <use xlink:href="#shape-lock-clasp-outer" mask="url(#mask-clasp-cutout)" class="icon-default" />
+  <use xlink:href="#shape-lock-base" mask="url(#mask-base-cutout)" class="icon-default" />
+
+  <line x1="2" y1="14.1" x2="14" y2="2.5" stroke="#d92d21" stroke-width="1.8" />
+</svg>

--- a/app/ui/shared/assets/ssl-secure.svg
+++ b/app/ui/shared/assets/ssl-secure.svg
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+     width="16" height="16" viewBox="0 0 16 16">
+  <style>
+    .icon-default {
+      fill: #4d9a26;
+    }
+  </style>
+
+  <defs>
+    <rect id="shape-lock-clasp-outer" x="4" y="2" width="8" height="10" rx="4" ry="4" />
+    <rect id="shape-lock-clasp-inner" x="6" y="4" width="4" height="6" rx="2" ry="2" />
+    <rect id="shape-lock-base" x="3" y="7" width="10" height="7" rx="1" ry="1" />
+
+    <mask id="mask-clasp-cutout">
+      <rect width="16" height="16" fill="#000" />
+      <use xlink:href="#shape-lock-clasp-outer" fill="#fff" />
+      <use xlink:href="#shape-lock-clasp-inner" fill="#000" />
+    </mask>
+  </defs>
+
+  <use xlink:href="#shape-lock-clasp-outer" mask="url(#mask-clasp-cutout)" class="icon-default" />
+  <use xlink:href="#shape-lock-base" class="icon-default" />
+</svg>


### PR DESCRIPTION
This does not handle the scenario where it loads a page with SSL errors and fails, since it'll still display a green lock (although the page doesn't load, so no bad things can happen).

Once #1107 lands, can do a follow up to parse any certificate errors available and display invalid SSL icons even when the page doesn't load.