### PR TITLE
Name generators used in saga so that redux-saga logs helpful "${generator} has been cancelled" messages

### DIFF
--- a/app/ui/browser-modern/sagas/helpers.js
+++ b/app/ui/browser-modern/sagas/helpers.js
@@ -18,12 +18,14 @@ import { logger } from '../../../shared/logging';
 export const failed = type => ({ type: `${type}_FAILED` });
 
 export const wrapped = function(type, fn) {
-  return [type, function*(...args) {
+  const generator = function*(...args) {
     try {
       yield* fn(...args);
     } catch (e) {
       yield put(failed(type));
       logger.error(e);
     }
-  }];
+  };
+  Object.defineProperty(generator, 'name', { value: type });
+  return [type, generator];
 };


### PR DESCRIPTION
Signed-off-by: Victor Porof <vporof@mozilla.com>