### PR TITLE
Update page-metadata-parser to 0.4.1.

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "lodash": "4.15.0",
     "microtime-fast": "1.0.2",
     "morgan": "1.7.0",
-    "page-metadata-parser": "0.3.0",
+    "page-metadata-parser": "0.4.1",
     "react": "15.3.1",
     "react-addons-perf": "15.3.1",
     "react-addons-pure-render-mixin": "15.3.1",


### PR DESCRIPTION
Fixes #1067.

PMP seems to work fine in the overview and not cause any test failures or console warnings. Not sure what was wrong with it previously.