### PR TITLE
Stop keeping track of both history and `canGoBack` and `canGoForward` state from the webview. Fixes #1135

### DIFF
--- a/app/ui/browser-modern/model/page-state.js
+++ b/app/ui/browser-modern/model/page-state.js
@@ -17,9 +17,6 @@ import SSLCertificate from './ssl-certificate';
 const PageState = Immutable.Record({
   load: undefined,
   navigationType: undefined,
-  canGoBack: false,
-  canGoForward: false,
-  canRefresh: false,
   zoomLevel: 0,
   searchVisible: false,
   code: undefined,

--- a/app/ui/browser-modern/selectors/pages.js
+++ b/app/ui/browser-modern/selectors/pages.js
@@ -80,6 +80,21 @@ export function getPageState(state, id) {
   return getPageById(state, id).state;
 }
 
+export function getPageCanGoBack(state, id) {
+  const { historyIndex } = getPageById(state, id);
+  return historyIndex > 0;
+}
+
+export function getPageCanGoForward(state, id) {
+  const { history, historyIndex } = getPageById(state, id);
+  return historyIndex < history.size - 1;
+}
+
+export function getPageCanRefresh() {
+  // Nothing prevents a page from being able to refresh yet.
+  return true;
+}
+
 export function getPageSearchVisible(state, id) {
   return getPageState(state, id).searchVisible;
 }

--- a/app/ui/browser-modern/setup-ipc.js
+++ b/app/ui/browser-modern/setup-ipc.js
@@ -48,24 +48,24 @@ export default function({ store, userAgentClient }) {
 
   ipcRenderer.on('go-back', () => {
     const pageId = PagesSelectors.getSelectedPageId(store.getState());
-    const pageState = PagesSelectors.getPageState(store.getState(), pageId);
-    if (pageState.canGoBack && !UISelectors.getOverviewVisible(store.getState())) {
+    const pageCanGoBack = PagesSelectors.getPageCanGoBack(store.getState(), pageId);
+    if (pageCanGoBack && !UISelectors.getOverviewVisible(store.getState())) {
       store.dispatch(PageEffects.navigateCurrentPageBack());
     }
   });
 
   ipcRenderer.on('go-forward', () => {
     const pageId = PagesSelectors.getSelectedPageId(store.getState());
-    const pageState = PagesSelectors.getPageState(store.getState(), pageId);
-    if (pageState.canGoForward && !UISelectors.getOverviewVisible(store.getState())) {
+    const pageCanGoForward = PagesSelectors.getPageCanGoForward(store.getState(), pageId);
+    if (pageCanGoForward && !UISelectors.getOverviewVisible(store.getState())) {
       store.dispatch(PageEffects.navigateCurrentPageForward());
     }
   });
 
   ipcRenderer.on('page-refresh', () => {
     const pageId = PagesSelectors.getSelectedPageId(store.getState());
-    const pageState = PagesSelectors.getPageState(store.getState(), pageId);
-    if (pageState.canRefresh && !UISelectors.getOverviewVisible(store.getState())) {
+    const pageCanRefresh = PagesSelectors.getPageCanRefresh(store.getState(), pageId);
+    if (pageCanRefresh && !UISelectors.getOverviewVisible(store.getState())) {
       store.dispatch(PageEffects.navigateCurrentPageRefresh());
     }
   });

--- a/app/ui/browser-modern/views/browser/navbar/index.jsx
+++ b/app/ui/browser-modern/views/browser/navbar/index.jsx
@@ -153,9 +153,9 @@ NavBar.propTypes = {
 function mapStateToProps(state, ownProps) {
   const page = PagesSelectors.getPageById(state, ownProps.pageId);
   return {
-    pageCanGoBack: page ? page.state.canGoBack : false,
-    pageCanGoForward: page ? page.state.canGoForward : false,
-    pageCanRefresh: page ? page.state.canRefresh : false,
+    pageCanGoBack: page ? PagesSelectors.getPageCanGoBack(state, ownProps.pageId) : false,
+    pageCanGoForward: page ? PagesSelectors.getPageCanGoForward(state, ownProps.pageId) : false,
+    pageCanRefresh: page ? PagesSelectors.getPageCanRefresh(state, ownProps.pageId) : false,
     pageHistory: page ? page.history : null,
   };
 }

--- a/app/ui/browser-modern/views/browser/page/index.jsx
+++ b/app/ui/browser-modern/views/browser/page/index.jsx
@@ -185,12 +185,6 @@ class Page extends Component {
     });
 
     this.webview.addEventListener('dom-ready', () => {
-      this.props.dispatch(PageActions.setPageState(this.props.pageId, {
-        canGoBack: this.webview.canGoBack(),
-        canGoForward: this.webview.canGoForward(),
-        canRefresh: true,
-      }));
-
       // Make sure we record this page navigation in the remote history
       // only after we have a title available. However, we can't do it in
       // the `page-title-set` because that event isn't fired when no title

--- a/app/ui/shared/util/webview-controller.js
+++ b/app/ui/shared/util/webview-controller.js
@@ -33,9 +33,10 @@ export default class WebViewController extends EventEmitter {
   navigateBack(pageId) {
     const pages = this.getPages();
     const index = getPageIndexById(pages, pageId);
+    const canGoBack = pages.get(index).historyIndex > 0;
     assert(index >= 0, `Page ${pageId} not found in current state.`);
     assert(isUUID(pageId), `Invalid page id: ${pageId}`);
-    assert(pages.get(index).state.canGoBack, 'Page cannot go back.');
+    assert(canGoBack, 'Page cannot go back.');
 
     this.emit('navigate-back', pageId);
     this.emit(`navigate-back:${pageId}`, pageId);
@@ -44,9 +45,10 @@ export default class WebViewController extends EventEmitter {
   navigateForward(pageId) {
     const pages = this.getPages();
     const index = getPageIndexById(pages, pageId);
+    const canGoForward = pages.get(index).historyIndex < pages.get(index).history.size - 1;
     assert(index >= 0, `Page ${pageId} not found in current state.`);
     assert(isUUID(pageId), `Invalid page id: ${pageId}`);
-    assert(pages.get(index).state.canGoForward, 'Page cannot go forward.');
+    assert(canGoForward, 'Page cannot go forward.');
 
     this.emit('navigate-forward', pageId);
     this.emit(`navigate-forward:${pageId}`, pageId);
@@ -79,7 +81,6 @@ export default class WebViewController extends EventEmitter {
     const index = getPageIndexById(pages, pageId);
     assert(index >= 0, `Page ${pageId} not found in current state.`);
     assert(isUUID(pageId), `Invalid page id: ${pageId}`);
-    assert(pages.get(index).state.canRefresh, 'Page cannot refresh.');
 
     this.emit('navigate-refresh', pageId);
     this.emit(`navigate-refresh:${pageId}`, pageId);


### PR DESCRIPTION
Fixes https://github.com/mozilla/tofino/issues/1135

Signed-off-by: Victor Porof <vporof@mozilla.com>