### PR TITLE
Propogate click events from webviews and close popups like autocomple…

### DIFF
--- a/app/ui/browser-modern/views/browser/page/index.jsx
+++ b/app/ui/browser-modern/views/browser/page/index.jsx
@@ -204,6 +204,26 @@ class Page extends Component {
           break;
       }
     });
+
+    // We cannot bind click events on the actual webview node, but mousedown
+    // works, so convert that to a propogated click.
+    this.webview.addEventListener('mousedown', e => {
+      this.handleWebviewClick(e);
+    });
+  }
+
+  /**
+   * Intercept and propogate clicks from the webview so we can react (like close popups)
+   * on events from webview.
+   */
+  handleWebviewClick() {
+    const ev = new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      view: window,
+      relatedTarget: this.webview,
+    });
+    this.webview.dispatchEvent(ev);
   }
 
   render() {

--- a/app/ui/shared/widgets/autocompleted-search.jsx
+++ b/app/ui/shared/widgets/autocompleted-search.jsx
@@ -37,11 +37,32 @@ class AutocompletedSearch extends Component {
     this.shouldComponentUpdate = ComponentUtil.shouldMixedPropsComponentUpdate.bind(this, {
       immutables: ['dataSrc'],
     });
+    this.handleWindowClick = this.handleWindowClick.bind(this);
 
     this.state = {
       showSelectionList: false,
       selectedIndex: 0,
     };
+  }
+
+  componentWillMount() {
+    if (typeof window === 'object') {
+      window.addEventListener('click', this.handleWindowClick);
+    }
+  }
+
+  componentWillUnmount() {
+    if (typeof window === 'object') {
+      window.removeEventListener('click', this.handleWindowClick);
+    }
+  }
+
+  handleWindowClick() {
+    // This component's button won't be available if hasn't rendered yet.
+    // We also can't call `setState` on components which haven't rendered yet.
+    if (this.state.showSelectionList && this.inputbar) {
+      this.setState({ showSelectionList: false });
+    }
   }
 
   handleInputChange = e => {


### PR DESCRIPTION
…te list when clicking outside the chrome area. Fixes #1123. r=vporof

How's something like this for handling clicks? The webview event doesn't emit a click event on its own; also, have not tested, but wonder if content can stop click events from hitting this, and if so, how common is that.