### PR TITLE
Set sourcemaps back to eval mode, due to page-metadata-parser not wor…

### DIFF
--- a/build/config/webpack.base.snippets.dev.js
+++ b/build/config/webpack.base.snippets.dev.js
@@ -7,10 +7,7 @@ export default {
   output: {
     pathinfo: true,
   },
-  // Something in `fathom-web/utils.js` breaks when eval'd,
-  // so don't use the 'eval' tool for now, even though it's a
-  // cheaper sourcemap generator.
-  devtool: 'cheap-source-map',
+  devtool: 'eval',
   plugins: [
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': '"development"',


### PR DESCRIPTION
…king currently anyway, and 'eval' gives us true authored source. r=bgrins

Fixes #1132 