### PR TITLE
Make tab hovering and clicking more accurate

### DIFF
--- a/app/ui/browser-modern/constants/ui.js
+++ b/app/ui/browser-modern/constants/ui.js
@@ -19,7 +19,9 @@ export const HOME_PAGE = ContentURLs.HISTORY_PAGE;
 export const TABBAR_HEIGHT = 39; // px
 export const TAB_DEFAULT_WIDTH = 240; // px
 export const TAB_MIN_WIDTH = 60; // px
+export const TAB_HEIGHT = 29; // px
 export const TAB_OVERLAP = 15; // px
+export const NEW_TAB_BUTTON_WIDTH = 66; // px
 
 // Navbar dimensions.
 export const NAVBAR_HEIGHT = 40; // px

--- a/app/ui/browser-modern/views/browser/tabbar/index.jsx
+++ b/app/ui/browser-modern/views/browser/tabbar/index.jsx
@@ -16,25 +16,20 @@ import { connect } from 'react-redux';
 
 import Style from '../../../../shared/style';
 import TabsList from './tabs-list';
-import Btn from '../../../../shared/widgets/btn';
+import NewTabBtn from './new-tab-btn';
 
 import * as UIConstants from '../../../constants/ui';
 import * as PageEffects from '../../../actions/page-effects';
 
 const TABBAR_STYLE = Style.registerStyle({
   flex: 1,
-  alignItems: 'center',
+  alignItems: 'flex-end',
   overflow: 'hidden',
   boxSizing: 'border-box',
   height: `${UIConstants.TABBAR_HEIGHT}px`,
-  paddingTop: '10px',
-  paddingRight: '38px',
+  paddingRight: '15px',
   boxShadow: 'inset 0 -1px 0px 0px var(--theme-tabbar-border-bottom-color)',
   background: 'var(--theme-tabbar-background)',
-});
-
-const NEW_TAB_BUTTON_STYLE = Style.registerStyle({
-  marginLeft: '-6px',
 });
 
 class TabBar extends Component {
@@ -52,18 +47,7 @@ class TabBar extends Component {
       <div id="browser-tabbar"
         className={TABBAR_STYLE}>
         <TabsList />
-        <Btn id="new-tab-button"
-          className={NEW_TAB_BUTTON_STYLE}
-          title="New tab"
-          width="18px"
-          height="20px"
-          image="newtab.png"
-          imgWidth="54px"
-          imgHeight="20px"
-          imgPosition="0px 0px"
-          imgPositionHover="-18px 0px"
-          imgPositionActive="-36px 0px"
-          onClick={this.handleNewTabClick} />
+        <NewTabBtn />
       </div>
     );
   }

--- a/app/ui/browser-modern/views/browser/tabbar/new-tab-btn.jsx
+++ b/app/ui/browser-modern/views/browser/tabbar/new-tab-btn.jsx
@@ -1,0 +1,74 @@
+/*
+Copyright 2016 Mozilla
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License. You may obtain a copy of the
+License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/
+
+import React, { Component, PropTypes } from 'react';
+import PureRenderMixin from 'react-addons-pure-render-mixin';
+import { connect } from 'react-redux';
+
+import Style from '../../../../shared/style';
+import Btn from '../../../../shared/widgets/btn';
+import TabVisuals from './tab-visuals';
+
+import * as UIConstants from '../../../constants/ui';
+import * as PageEffects from '../../../actions/page-effects';
+
+const NEW_TAB_BUTTON_CONTAINER_STYLE = Style.registerStyle({
+  // Due to its visual elements, this component's bounds are much larger than
+  // the area we want to be clickable. Since it can overlap other interactive
+  // components, restrict the pointer events only to relevant children.
+  pointerEvents: 'none',
+  position: 'relative',
+  flexShrink: 0,
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: `${UIConstants.NEW_TAB_BUTTON_WIDTH}px`,
+  height: `${UIConstants.TAB_HEIGHT}px`,
+  marginLeft: `-${UIConstants.TAB_OVERLAP * 2}px`,
+});
+
+class NewTabBtn extends Component {
+  constructor(props) {
+    super(props);
+    this.shouldComponentUpdate = PureRenderMixin.shouldComponentUpdate.bind(this);
+  }
+
+  handleNewTabClick = () => {
+    this.props.dispatch(PageEffects.createPageSession());
+  }
+
+  render() {
+    return (
+      <div className={NEW_TAB_BUTTON_CONTAINER_STYLE}>
+        <Btn className="browser-new-tab-button"
+          title="New tab"
+          width="18px"
+          height="20px"
+          image="newtab.png"
+          imgWidth="54px"
+          imgHeight="20px"
+          imgPosition="0px 0px"
+          imgPositionHover="-18px 0px"
+          imgPositionActive="-36px 0px"
+          onClick={this.handleNewTabClick} />
+        <TabVisuals />
+      </div>
+    );
+  }
+}
+
+NewTabBtn.displayName = 'NewTabBtn';
+
+NewTabBtn.propTypes = {
+  dispatch: PropTypes.func.isRequired,
+};
+
+export default connect()(NewTabBtn);

--- a/app/ui/browser-modern/views/browser/tabbar/tab-pointer-area.jsx
+++ b/app/ui/browser-modern/views/browser/tabbar/tab-pointer-area.jsx
@@ -1,0 +1,60 @@
+/*
+Copyright 2016 Mozilla
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License. You may obtain a copy of the
+License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/
+
+import React, { Component, PropTypes } from 'react';
+import PureRenderMixin from 'react-addons-pure-render-mixin';
+
+import Style from '../../../../shared/style';
+
+/**
+ * Tab components are visually laid out in such a way that resuts in complex
+ * overlapping due to their visual elements. Therefore, pointer interaction
+ * would be hidered if relying on the default bounds alone. This component is
+ * responsible for providing an explicitly interactive rectangular area for tabs.
+ */
+
+const TAB_POINTER_AREA_STYLE = Style.registerStyle({
+  // Make sure this is underneath other sibling interactive elements.
+  zIndex: -1,
+  pointerEvents: 'all',
+  position: 'absolute',
+  left: '15px',
+  right: '15px',
+  top: 0,
+  bottom: 0,
+});
+
+class TabPointerArea extends Component {
+  constructor(props) {
+    super(props);
+    this.shouldComponentUpdate = PureRenderMixin.shouldComponentUpdate.bind(this);
+  }
+
+  render() {
+    return (
+      <div className={`tab-pointer-area ${TAB_POINTER_AREA_STYLE}`}
+        title={this.props.tooltipText}
+        onMouseDown={this.props.onMouseDown}
+        onMouseUp={this.props.onMouseUp} />
+    );
+  }
+}
+
+TabPointerArea.displayName = 'TabPointerArea';
+
+TabPointerArea.propTypes = {
+  tooltipText: PropTypes.string.isRequired,
+  onMouseDown: PropTypes.func,
+  onMouseUp: PropTypes.func,
+};
+
+export default TabPointerArea;

--- a/app/ui/browser-modern/views/browser/tabbar/tab-visuals.jsx
+++ b/app/ui/browser-modern/views/browser/tabbar/tab-visuals.jsx
@@ -17,11 +17,13 @@ import Style from '../../../../shared/style';
 
 /**
  * This component is simply responsible for rendering the curvy tabs background
- * in a purely presentational fashion.
+ * in a purely visual non-interactive non-layout-affecting fashion.
  */
 
 const TAB_VISUALS_STYLE = Style.registerStyle({
+  // Interaction with this component is not intended.
   pointerEvents: 'none',
+  // Make sure this is underneath other sibling interactive or visual elements.
   zIndex: -1,
 });
 
@@ -38,12 +40,15 @@ const TAB_SIDES_BACKGROUND_STYLE = Style.registerStyle({
     right 0px bottom -1px,
     left 0px bottom -1px,
     right 0px bottom -1px`,
-  '[data-active-tab=false]:hover &': {
+  [`.browser-tab[data-active-tab=false] > .tab-pointer-area:hover ~ .tab-visuals > &,
+    .browser-tab[data-active-tab=false] > .tab-close-button:hover ~ .tab-visuals > &,
+    .browser-new-tab-button:hover ~ .tab-visuals > &`
+  ]: {
     backgroundImage: `
       url('assets/tab-background-start.png'),
       url('assets/tab-background-end.png')`,
   },
-  '[data-active-tab=true] &': {
+  '.browser-tab[data-active-tab=true] > .tab-visuals > &': {
     backgroundImage: `
       url('assets/tab-stroke-start.png'),
       url('assets/tab-stroke-end.png'),
@@ -61,11 +66,14 @@ const TAB_CENTER_BACKGROUND_STYLE = Style.registerStyle({
   backgroundSize: '6px 31px',
   backgroundRepeat: 'repeat-x',
   backgroundPosition: 'left 0px bottom -1px',
-  '[data-active-tab=false]:hover &': {
+  [`.browser-tab[data-active-tab=false] > .tab-pointer-area:hover ~ .tab-visuals > &,
+    .browser-tab[data-active-tab=false] > .tab-close-button:hover ~ .tab-visuals > &,
+    .browser-new-tab-button:hover ~ .tab-visuals > &`
+  ]: {
     backgroundImage: `
       url('assets/tab-background-middle.png')`,
   },
-  '[data-active-tab=true] &': {
+  '.browser-tab[data-active-tab=true] > .tab-visuals > &': {
     backgroundImage: `
       url('assets/tab-selected-middle.png'),
       linear-gradient(transparent 2px, hsl(0,0%,99%) 2px, hsl(0,0%,93%))`,

--- a/app/ui/browser-modern/views/browser/tabbar/tab.jsx
+++ b/app/ui/browser-modern/views/browser/tabbar/tab.jsx
@@ -16,6 +16,7 @@ import { connect } from 'react-redux';
 
 import Style from '../../../../shared/style';
 import Btn from '../../../../shared/widgets/btn';
+import TabPointerArea from './tab-pointer-area';
 import TabVisuals from './tab-visuals';
 import TabContents from './tab-contents';
 
@@ -26,14 +27,17 @@ import * as PageActions from '../../../actions/page-actions';
 import * as PageEffects from '../../../actions/page-effects';
 
 const TAB_STYLE = Style.registerStyle({
-  WebkitUserSelect: 'none',
-  WebkitAppRegion: 'no-drag',
+  // Due to its visual elements, this component's bounds are much larger than
+  // the area we want to be clickable. Since it can overlap other interactive
+  // components, restrict the pointer events only to relevant children.
+  pointerEvents: 'none',
   position: 'relative',
   alignItems: 'center',
   overflow: 'hidden',
   boxSizing: 'border-box',
   width: `${UIConstants.TAB_DEFAULT_WIDTH}px`,
   minWidth: `${UIConstants.TAB_MIN_WIDTH}px`,
+  height: `${UIConstants.TAB_HEIGHT}px`,
   margin: `0 -${UIConstants.TAB_OVERLAP}px`,
   padding: '0 24px',
   backgroundImage: 'var(--theme-window-background)',
@@ -46,20 +50,9 @@ const TAB_STYLE = Style.registerStyle({
     color: 'var(--theme-tab-active-color)',
     textShadow: '0 1px var(--theme-tab-active-text-shadow)',
     opacity: 'var(--theme-tab-active-opacity)',
+    // Make sure this is displayed above other sibling tabs.
     zIndex: 1,
   },
-});
-
-const TAB_POINTER_AREA_STYLE = Style.registerStyle({
-  position: 'absolute',
-  left: '15px',
-  right: '15px',
-  top: 0,
-  bottom: 0,
-});
-
-const TAB_CLOSE_BUTTON_STYLE = Style.registerStyle({
-  zIndex: 1,
 });
 
 class Tab extends Component {
@@ -102,12 +95,8 @@ class Tab extends Component {
         data-active-tab={this.props.isActive && !this.props.isOverviewVisible}
         data-before-active-tab={this.props.isBeforeActive && !this.props.isOverviewVisible}
         data-after-active-tab={this.props.isAfterActive && !this.props.isOverviewVisible}>
-        <div className={`tab-pointer-area ${TAB_POINTER_AREA_STYLE}`}
-          title={this.props.pageTitle || this.props.pageLocation}
-          onMouseDown={this.handleTabPick} />
-        <TabVisuals />
         <TabContents pageId={this.props.pageId} />
-        <Btn className={`tab-close-button ${TAB_CLOSE_BUTTON_STYLE}`}
+        <Btn className="tab-close-button"
           title="Close tab"
           width="14px"
           height="14px"
@@ -118,6 +107,9 @@ class Tab extends Component {
           imgPositionHover="-17px -1px"
           imgPositionActive="-33px -1px"
           onClick={this.handleTabClose} />
+        <TabPointerArea tooltipText={this.props.pageTitle || this.props.pageLocation}
+          onMouseDown={this.handleTabPick} />
+        <TabVisuals />
       </div>
     );
   }

--- a/app/ui/browser-modern/views/browser/tabbar/tabs-list.jsx
+++ b/app/ui/browser-modern/views/browser/tabbar/tabs-list.jsx
@@ -22,8 +22,9 @@ import * as SharedPropTypes from '../../../model/shared-prop-types';
 import * as PagesSelectors from '../../../selectors/pages';
 
 const TABS_LIST_STYLE = Style.registerStyle({
+  WebkitUserSelect: 'none',
+  WebkitAppRegion: 'no-drag',
   overflow: 'hidden',
-  alignSelf: 'stretch',
   padding: `0 ${UIConstants.TAB_OVERLAP}px`,
 });
 

--- a/app/ui/shared/widgets/btn.jsx
+++ b/app/ui/shared/widgets/btn.jsx
@@ -25,6 +25,7 @@ export const BKG_SIZE_DEFAULT = 'contain';
 const BUTTON_STYLE = Style.registerStyle({
   WebkitUserSelect: 'none',
   WebkitAppRegion: 'no-drag',
+  pointerEvents: 'all',
   display: 'flex',
   flexShrink: 0,
   alignItems: 'center',


### PR DESCRIPTION
Fixes https://github.com/mozilla/tofino/issues/1223 among other things.

Currently clicking and hovering tabs is very imprecise. This is due to the complex overlapping between them. This patch attempts to make everything explicit and precise.

At the same time, it adds the 'ghost tab' background when hovering the new tab button by using the same TabVisuals component used for normal tabs.

Signed-off-by: Victor Porof <vporof@mozilla.com>