### PR TITLE
Downgrade page-metadata-parser to 0.3.0 and do not use 'eval' type so…

### DIFF
--- a/build/config/webpack.preload.js
+++ b/build/config/webpack.preload.js
@@ -17,6 +17,7 @@ export default {
     filename: 'index.js',
     sourceMapFilename: 'index.map',
   },
+  devtool: 'cheap-module-source-map',
   plugins: [
     ...defaultConfig.plugins,
     new webpack.DefinePlugin({

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "lodash": "4.16.0",
     "microtime-fast": "1.0.2",
     "morgan": "1.7.0",
-    "page-metadata-parser": "0.4.1",
+    "page-metadata-parser": "0.3.0",
     "react": "15.3.2",
     "react-addons-perf": "15.3.1",
     "react-addons-pure-render-mixin": "15.3.2",


### PR DESCRIPTION
…urce map on preload scripts due to fathom-web breakage. Fixes #1179. r=vporof