### PR TITLE
Spawn User Agent Service during tests instead of embedding a UserAgentService.

### DIFF
--- a/test/unit/user-agent-service/test-server.js
+++ b/test/unit/user-agent-service/test-server.js
@@ -6,9 +6,9 @@ import expect from 'expect';
 import fs from 'fs';
 import path from 'path';
 import tmp from 'tmp';
-import { UserAgentService } from '../../../app/services/user-agent-service';
-import { UserAgentHttpClient } from '../../../app/shared/user-agent-http-client';
+import UserAgentClient from '../../../app/shared/user-agent-client';
 import * as endpoints from '../../../app/shared/constants/endpoints';
+import * as spawn from '../../../app/main/spawn';
 
 describe('User Agent Service', () => {
   let tempDir = null;
@@ -22,17 +22,21 @@ describe('User Agent Service', () => {
     (async function () {
       try {
         port += 1; // Advance first, so that we don't stick on a blocked port.
-        stop = await UserAgentService( // eslint-disable-line
-          {
-            port,
-            db: tempDir,
-            version: 'v1',
-            contentServiceOrigin: `${endpoints.TOFINO_PROTOCOL}://`,
-          });
-        userAgentHttpClient = new UserAgentHttpClient({
+        const userAgentClient = new UserAgentClient();
+
+        const [connected, _stop, _child] = spawn.startUserAgentService(userAgentClient, {
+          attached: true, // We want to see stdout and stderr.
+          port,
           version: 'v1',
-          host: endpoints.UA_SERVICE_ADDR,
-          port });
+          contentServiceOrigin: `${endpoints.TOFINO_PROTOCOL}://`,
+          profiledir: tempDir,
+          libdir: path.join(__dirname, '..', '..', '..', 'lib'), // LIBDIR is not set by webpack during tests.
+        });
+        stop = _stop;
+
+        await connected;
+
+        userAgentHttpClient = userAgentClient.userAgentHttpClient;
 
         done();
       } catch (e) {


### PR DESCRIPTION
jsantell and I discussed this on Vidyo, and we agreed that the
"boundary" for the User Agent Service should be a shell
script (bin/user-agent-service) with fixed parameters, provided by an
NPM dependency.  The alternative would be to have the "boundary" be a
JavaScript API allowing to embed a UserAgentService, like we had for the
current tests.  This patch removes that embedding usage from the Tofino
tree, paving the way for externalizing the shell script.

@mossop you seem like the best person to review this.  It may take some time for me to get the tests passing in automation, but the review can proceed apace.