### PR TITLE
Fix `code` and `description` prop warnings on the NetErrorPage when swipe-navigating back from a page with certificate errors

### DIFF
--- a/app/ui/browser-modern/views/browser/page/error-page.jsx
+++ b/app/ui/browser-modern/views/browser/page/error-page.jsx
@@ -18,8 +18,9 @@ import Style from '../../../../shared/style';
 import NetErrorPage from './net-error';
 import CertErrorPage from './cert-error';
 
-import * as SharedPropTypes from '../../../model/shared-prop-types';
+import PageState from '../../../model/page-state';
 import * as PagesSelectors from '../../../selectors/pages';
+import * as SharedPropTypes from '../../../model/shared-prop-types';
 
 const ERROR_PAGE_STYLE = Style.registerStyle({
   width: '100%',
@@ -77,6 +78,7 @@ ErrorPage.propTypes = {
 function mapStateToProps(state, ownProps) {
   const page = PagesSelectors.getPageById(state, ownProps.pageId);
   return {
+    hidden: page.state.load !== PageState.STATES.FAILED,
     pageLocation: page.location,
     pageState: page.state,
   };

--- a/app/ui/browser-modern/views/browser/page/index.jsx
+++ b/app/ui/browser-modern/views/browser/page/index.jsx
@@ -230,8 +230,7 @@ class Page extends Component {
     return (
       <div id={`browser-page-${this.props.pageId}`}
         className={`browser-page ${PAGE_STYLE}`}>
-        <ErrorPage pageId={this.props.pageId}
-          hidden={!this.props.showErrorPage} />
+        <ErrorPage pageId={this.props.pageId} />
         <webview is="webview"
           ref={e => this.webview = e}
           class={WEB_VIEW_STYLE}
@@ -246,14 +245,6 @@ Page.displayName = 'Page';
 Page.propTypes = {
   dispatch: PropTypes.func.isRequired,
   pageId: PropTypes.string.isRequired,
-  showErrorPage: PropTypes.bool.isRequired,
 };
 
-function mapStateToProps(state, ownProps) {
-  const page = PagesSelectors.getPageById(state, ownProps.pageId);
-  return {
-    showErrorPage: page.state.load === PageState.STATES.FAILED,
-  };
-}
-
-export default connect(mapStateToProps)(Page);
+export default connect()(Page);


### PR DESCRIPTION
Fixes https://github.com/mozilla/tofino/issues/1292

See issue for explanation.
This is the most amazing bug. I'm out. *drops mic*

Signed-off-by: Victor Porof <vporof@mozilla.com>