### PR TITLE
Don't allow clicks to go through to the webview when autocomplete popup is opened

### DIFF
--- a/app/ui/shared/widgets/autocompleted-search.jsx
+++ b/app/ui/shared/widgets/autocompleted-search.jsx
@@ -47,20 +47,24 @@ class AutocompletedSearch extends Component {
 
   componentWillMount() {
     if (typeof window === 'object') {
-      window.addEventListener('click', this.handleWindowClick);
+      window.addEventListener('mousedown', this.handleWindowMousedown);
     }
   }
 
   componentWillUnmount() {
     if (typeof window === 'object') {
-      window.removeEventListener('click', this.handleWindowClick);
+      window.removeEventListener('mousedown', this.handleWindowMousedown);
     }
   }
 
-  handleWindowClick = () => {
+  // We need to use mousedown since preventing the event on click won't stop
+  // it from passing through to the webview.  Note that this will only be fired
+  // when the mousedown happened outside the selection list
+  handleWindowMousedown = (e) => {
     // We can't call `setState` on components which haven't rendered yet.
     if (this.state.showSelectionList && this.inputbar) {
       this.setState({ showSelectionList: false });
+      e.preventDefault();
     }
   }
 
@@ -127,6 +131,13 @@ class AutocompletedSearch extends Component {
     this.props.onKeyDown(e);
   }
 
+  // The the list has been moused down, then don't let that bubble up
+  // to the window, because that would cause the list to become closed
+  // before the item gets selected.
+  handleMouseDownOnSelectionList = (e) => {
+    e.stopPropagation();
+  }
+
   handleMouseOverChildComponent = component => {
     const index = component.props['data-index'];
     this.setState({ selectedIndex: index });
@@ -158,6 +169,7 @@ class AutocompletedSearch extends Component {
         <SelectionList className={`${SELECTION_LIST_STYLE} ${this.props.dropdownListClassName || ''}`}
           hidden={!this.state.showSelectionList}
           selectedIndex={this.state.selectedIndex}
+          onMouseDown={this.handleMouseDownOnSelectionList}
           onMouseOverChildComponent={this.handleMouseOverChildComponent}
           onClickOnChildComponent={this.handleClickOnChildComponent}>
           {this.props.dataSrc && this.props.dataSrc.map(this.createChild).toArray()}

--- a/app/ui/shared/widgets/autocompleted-search.jsx
+++ b/app/ui/shared/widgets/autocompleted-search.jsx
@@ -58,11 +58,13 @@ class AutocompletedSearch extends Component {
   }
 
   // We need to use mousedown since preventing the event on click won't stop
-  // it from passing through to the webview.  Note that this will only be fired
-  // when the mousedown happened outside the selection list
+  // it from passing through to the webview.
   handleWindowMousedown = (e) => {
-    // We can't call `setState` on components which haven't rendered yet.
-    if (this.state.showSelectionList && this.inputbar) {
+    // We can't call `setState` on components which haven't rendered yet,
+    // and we only want to hide / prevent if the target is outside of the
+    // select list.
+    if (this.state.showSelectionList && this.inputbar &&
+        !this.inputbar.container.contains(e.target)) {
       this.setState({ showSelectionList: false });
       e.preventDefault();
     }
@@ -131,13 +133,6 @@ class AutocompletedSearch extends Component {
     this.props.onKeyDown(e);
   }
 
-  // The the list has been moused down, then don't let that bubble up
-  // to the window, because that would cause the list to become closed
-  // before the item gets selected.
-  handleMouseDownOnSelectionList = (e) => {
-    e.stopPropagation();
-  }
-
   handleMouseOverChildComponent = component => {
     const index = component.props['data-index'];
     this.setState({ selectedIndex: index });
@@ -169,7 +164,6 @@ class AutocompletedSearch extends Component {
         <SelectionList className={`${SELECTION_LIST_STYLE} ${this.props.dropdownListClassName || ''}`}
           hidden={!this.state.showSelectionList}
           selectedIndex={this.state.selectedIndex}
-          onMouseDown={this.handleMouseDownOnSelectionList}
           onMouseOverChildComponent={this.handleMouseOverChildComponent}
           onClickOnChildComponent={this.handleClickOnChildComponent}>
           {this.props.dataSrc && this.props.dataSrc.map(this.createChild).toArray()}

--- a/app/ui/shared/widgets/search.jsx
+++ b/app/ui/shared/widgets/search.jsx
@@ -96,6 +96,7 @@ class Search extends Component {
   render() {
     return (
       <div {...omit(this.props, Object.keys(OmittedContainerProps))}
+         ref={e => this.container = e}
         className={`widget-search ${this.props.className || ''}`}>
         <input ref={e => this.input = e}
           className={INPUT_STYLE}

--- a/app/ui/shared/widgets/selection-list.jsx
+++ b/app/ui/shared/widgets/selection-list.jsx
@@ -76,7 +76,6 @@ const OmittedContainerProps = {
 
 SelectionList.propTypes = {
   ...OmittedContainerProps,
-  onMouseDown: PropTypes.func,
   className: PropTypes.string,
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),

--- a/app/ui/shared/widgets/selection-list.jsx
+++ b/app/ui/shared/widgets/selection-list.jsx
@@ -76,6 +76,7 @@ const OmittedContainerProps = {
 
 SelectionList.propTypes = {
   ...OmittedContainerProps,
+  onMouseDown: PropTypes.func,
   className: PropTypes.string,
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),


### PR DESCRIPTION
Fixes #1207.

There are two approaches here, the first (can be seen at https://github.com/mozilla/tofino/commit/44cc3e89561e0df852f842a5754fbd1bdea96b9f) binds to the mouseDown on the subcomponent then stops propagation up to the window.

The second (which can be seen as this PR) sets up a ref to the search container so we can do container.contains(e.target) as a lighter-weight way to check if we should prevent the mousedown from happening.

There's a third possible approach here which would be sending a change over to the webview to tell it to use `pointer-events: none` when the autocomplete popup is opened.  This would have the benefit of not showing hover states on things in the page when the popup is opened, but it also feels more heavyweight and less flexible if we want to somehow change this behavior in the future.

I'm leaning towards the approach that's currently in the PR, but @victorporof lmk what you think.  