### PR TITLE
Don't let mouse events on history items propogate to the navigation buttons

### DIFF
--- a/app/ui/shared/widgets/list-item.jsx
+++ b/app/ui/shared/widgets/list-item.jsx
@@ -29,16 +29,19 @@ class ListItem extends Component {
   handleMouseDown = e => {
     this.props.onMouseDown(e);
     this.props.onMouseDownOnComponent(this);
+    e.stopPropagation();
   }
 
   handleMouseUp = e => {
     this.props.onMouseUp(e);
     this.props.onMouseUpOnComponent(this);
+    e.stopPropagation();
   }
 
   handleMouseClick = e => {
     this.props.onClick(e);
     this.props.onClickOnComponent(this);
+    e.stopPropagation();
   }
 
   handleMouseOver = e => {


### PR DESCRIPTION
Clicking on history items in the list is currently also triggering a click on the navigation button the list came from so the webview gets told to load one index and then go forward/back looking like an off-by-one error. This fixes it by stopping propagation of the mouse events from list items but I'm not sure if that is too general or if we should do something specific for the dropdown button component instead.