### PR TITLE
Add Tofino to the registry as a handler for html and http and parse urls passed on the command line.

### DIFF
--- a/app/main/command-line.js
+++ b/app/main/command-line.js
@@ -12,7 +12,7 @@ import electron from 'electron';
 import { parse } from 'url';
 import * as BW from './browser-window';
 import * as protocols from './protocols';
-import { logger } from '../shared/logging';
+import { parseArgs } from '../shared/environment';
 
 const { app } = electron;
 const isDarwin = process.platform === 'darwin';
@@ -27,18 +27,12 @@ const isValidURL = url => {
   return protocols.DEFAULT_PROTOCOLS.includes(protocol.replace(/:$/, ''));
 };
 
-// Checks an array of arguments if it can find a url
-const getUrlFromCommandLine = () => {
-  logger.warn('getUrlFromCommandLine: not yet implemented, Issue #1210');
-  return undefined;
-};
-
 // For macOS, there are events like open-url instead
 if (!isDarwin) {
-  const openUrl = getUrlFromCommandLine(process.argv);
-  if (openUrl) {
-    if (isValidURL(openUrl)) {
-      BW.focusOrOpenWindow(openUrl);
+  // Checks an array of arguments if it can find a url
+  for (const arg of parseArgs()._) {
+    if (isValidURL(arg)) {
+      BW.focusOrOpenWindow(arg);
     }
   }
 }
@@ -50,7 +44,11 @@ app.on('ready', () => {
       if (isDarwin) {
         BW.focusOrOpenWindow();
       } else {
-        BW.focusOrOpenWindow(getUrlFromCommandLine(argv));
+        for (const arg of parseArgs(argv)._) {
+          if (isValidURL(arg)) {
+            BW.focusOrOpenWindow(arg);
+          }
+        }
       }
     });
     if (appAlreadyStartedShouldQuit) {

--- a/app/main/index.js
+++ b/app/main/index.js
@@ -15,6 +15,7 @@ specific language governing permissions and limitations under the License.
 
 import { logger } from '../shared/logging';
 import 'source-map-support/register';
+import { addToWindowsRegistry, removeFromWindowsRegistry } from './protocols';
 
 process.on('uncaughtException', err => {
   logger.error(err.stack);
@@ -29,6 +30,8 @@ process.on('unhandledRejection', (reason, p) => {
 
 import { app } from 'electron';
 import { argParser, parseArgs } from '../shared/environment';
+
+// See https://github.com/Squirrel/Squirrel.Windows/blob/master/docs/using/custom-squirrel-events-non-cs.md#application-startup-commands
 
 const SQUIRREL_VERSION_EVENTS = [
   'squirrel-install',
@@ -69,6 +72,22 @@ switch (seenEvent) {
   case SQUIRREL_FIRSTRUN_EVENT:
   case null:
     require('./browser');
+    break;
+
+  case 'squirrel-install':
+    addToWindowsRegistry().catch(e => {
+      logger.error(e);
+    }).then(() => {
+      app.quit();
+    });
+    break;
+
+  case 'squirrel-uninstall':
+    removeFromWindowsRegistry().catch(e => {
+      logger.error(e);
+    }).then(() => {
+      app.quit();
+    });
     break;
 
   // For all other events quit the app.

--- a/app/main/protocols.js
+++ b/app/main/protocols.js
@@ -11,8 +11,14 @@ specific language governing permissions and limitations under the License.
 */
 
 import { protocol, app } from 'electron';
+import tmp from 'tmp';
+import thenify from 'thenify';
+import fs from 'fs-promise';
+import childProcess from 'child_process';
 import * as endpoints from '../shared/constants/endpoints';
 
+const mktmp = thenify(tmp.file);
+const exec = thenify(childProcess.exec);
 const tofinoColonSlash = new RegExp(`^${endpoints.TOFINO_PROTOCOL}:/`);
 
 export const DEFAULT_PROTOCOLS = ['http', 'https', endpoints.TOFINO_PROTOCOL];
@@ -52,4 +58,94 @@ export function setDefaultBrowser() {
 
 export function isDefaultBrowser() {
   return DEFAULT_PROTOCOLS.every(p => app.isDefaultProtocolClient(p));
+}
+
+async function mergeRegistry(text) {
+  const [path, fd] = await mktmp();
+
+  await fs.write(fd, text, 0, 'utf8');
+  await fs.close(fd);
+  await exec(`regedit.exe /s ${path}`);
+}
+
+export async function addToWindowsRegistry() {
+  const exepath = process.execPath.replace(/\\/g, '\\\\');
+  await mergeRegistry(`Windows Registry Editor Version 5.00
+
+[HKEY_CLASSES_ROOT\\TofinoHTML]
+@="Tofino HTML Document"
+
+[HKEY_CLASSES_ROOT\\TofinoHTML\\DefaultIcon]
+@="${exepath},0"
+
+[HKEY_CLASSES_ROOT\\TofinoHTML\\shell]
+
+[HKEY_CLASSES_ROOT\\TofinoHTML\\shell\\open]
+
+[HKEY_CLASSES_ROOT\\TofinoHTML\\shell\\open\\command]
+@="\\"${exepath}\\" -- \\"%1\\""
+
+[HKEY_CURRENT_USER\\SOFTWARE\\Classes\\TofinoHTML]
+@="Tofino HTML Document"
+
+[HKEY_CURRENT_USER\\SOFTWARE\\Classes\\TofinoHTML\\DefaultIcon]
+@="${exepath},0"
+
+[HKEY_CURRENT_USER\\SOFTWARE\\Classes\\TofinoHTML\\shell]
+
+[HKEY_CURRENT_USER\\SOFTWARE\\Classes\\TofinoHTML\\shell\\open]
+
+[HKEY_CURRENT_USER\\SOFTWARE\\Classes\\TofinoHTML\\shell\\open\\command]
+@="\\"${exepath}\\" -- \\"%1\\""
+
+[HKEY_CURRENT_USER\\SOFTWARE\\Clients\\StartMenuInternet\\Tofino]
+@="Tofino"
+
+[HKEY_CURRENT_USER\\SOFTWARE\\Clients\\StartMenuInternet\\Tofino\\Capabilities]
+"ApplicationDescription"="Project Tofino"
+"ApplicationName"="Tofino"
+
+[HKEY_CURRENT_USER\\SOFTWARE\\Clients\\StartMenuInternet\\Tofino\\Capabilities\\FileAssociations]
+".htm"="TofinoHTML"
+".html"="TofinoHTML"
+".shtml"="TofinoHTML"
+".xht"="TofinoHTML"
+".xhtml"="TofinoHTML"
+".webp"="TofinoHTML"
+
+[HKEY_CURRENT_USER\\SOFTWARE\\Clients\\StartMenuInternet\\Tofino\\Capabilities\\StartMenu]
+"StartMenuInternet"="Tofino"
+
+[HKEY_CURRENT_USER\\SOFTWARE\\Clients\\StartMenuInternet\\Tofino\\Capabilities\\URLAssociations]
+"ftp"="TofinoHTML"
+"http"="TofinoHTML"
+"https"="TofinoHTML"
+
+[HKEY_CURRENT_USER\\SOFTWARE\\Clients\\StartMenuInternet\\Tofino\\InstallInfo]
+"IconsVisible"=dword:00000001
+
+[HKEY_CURRENT_USER\\SOFTWARE\\Clients\\StartMenuInternet\\Tofino\\shell]
+
+[HKEY_CURRENT_USER\\SOFTWARE\\Clients\\StartMenuInternet\\Tofino\\shell\\open]
+
+[HKEY_CURRENT_USER\\SOFTWARE\\Clients\\StartMenuInternet\\Tofino\\shell\\open\\command]
+@="${exepath}"
+
+[HKEY_CURRENT_USER\\SOFTWARE\\RegisteredApplications]
+"Tofino"="Software\\\\Clients\\\\StartMenuInternet\\\\Tofino\\\\Capabilities"
+`);
+}
+
+export async function removeFromWindowsRegistry() {
+  await mergeRegistry(`Windows Registry Editor Version 5.00
+
+[-HKEY_CLASSES_ROOT\\TofinoHTML]
+
+[-HKEY_CURRENT_USER\\SOFTWARE\\Classes\\TofinoHTML]
+
+[-HKEY_CURRENT_USER\\SOFTWARE\\Clients\\StartMenuInternet\\Tofino]
+
+[HKEY_CURRENT_USER\\SOFTWARE\\RegisteredApplications]
+"Tofino"=-
+`);
 }

--- a/app/package.json
+++ b/app/package.json
@@ -12,7 +12,9 @@
   "license": "Apache-2.0",
   "dependencies": {
     "datomish-user-agent-service": "0.0.2",
+    "fs-promise": "0.5.0",
     "request": "2.65.0",
+    "thenify": "3.2.0",
     "yargs": "5.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "redux-logger": "2.7.0",
     "redux-saga": "0.12.0",
     "source-map-support": "ncalexan/node-source-map-support#fileUrls-plus",
+    "tmp": "0.0.29",
     "uuid": "2.0.3",
     "why-did-you-update": "github:victorporof/why-did-you-update#immutable",
     "ws": "1.1.1"
@@ -111,7 +112,6 @@
     "sha1": "1.1.1",
     "spectron": "3.3.0",
     "thenify-all": "1.6.0",
-    "tmp": "0.0.29",
     "uglify-js": "github:mishoo/UglifyJS2#harmony",
     "webpack": "1.13.2",
     "yargs": "6.0.0",


### PR DESCRIPTION
This adds Tofino as a browser to the windows registry on install and removes on uninstall. It's a bit clunky, you get a UAC escalation request from regedit but it works for now. After that you can choose tofino in the windows default apps list.

The command line handling is a bit clunky too. It might be nice to rework that at some point but it works for now.

Currently as long as the app is already open links open in a new tab. If the app isn't open it fails because of #1321.