### PR TITLE
Download notification should show full path of download. Fixes #1361.…

### DIFF
--- a/app/main/downloads.js
+++ b/app/main/downloads.js
@@ -17,6 +17,10 @@ export function registerDownloadHandlers(bw) {
       filename: item.getFilename(),
     };
     item.once('done', (_event, state) => {
+      // Set `path` after the item is done, since it is not yet
+      // set by the time `will-download` is fired.
+      itemData.path = item.getSavePath();
+
       if (state === 'completed') {
         bw.send('download-completed', itemData);
       } else {

--- a/app/ui/browser-modern/actions/ui-effects.js
+++ b/app/ui/browser-modern/actions/ui-effects.js
@@ -44,12 +44,13 @@ export function setCurrentURLBarValue(value, options) {
   };
 }
 
-export function showDownloadNotification({ url, filename, status }) {
+export function showDownloadNotification({ url, path, filename, status }) {
   return {
     type: EffectTypes.SHOW_DOWNLOAD_NOTIFICATION,
     url,
     filename,
     status,
+    path,
   };
 }
 

--- a/app/ui/browser-modern/sagas/ui-sagas.js
+++ b/app/ui/browser-modern/sagas/ui-sagas.js
@@ -70,12 +70,12 @@ function* setURLBarValue({ urlbar, value, doc, options = { keepSelection: true }
   }
 }
 
-function* showDownloadNotification({ filename, status }) {
+function* showDownloadNotification({ path, filename, status }) {
   let message;
   const title = `Download ${status === 'success' ? 'completed' : 'failed'}`;
 
   if (status === 'success') {
-    message = `Download for ${filename} is completed.`;
+    message = `Download for ${filename} is completed. Can be located at ${path}/${filename}`;
   } else if (status === 'error') {
     message = `Download for ${filename} has failed.`;
   }

--- a/app/ui/browser-modern/setup-ipc.js
+++ b/app/ui/browser-modern/setup-ipc.js
@@ -153,12 +153,12 @@ export default function({ store, userAgentClient }) {
     store.dispatch(PageEffects.captureCurrentPage());
   });
 
-  ipcRenderer.on('download-completed', (_, { url, filename }) => {
-    store.dispatch(UIEffects.showDownloadNotification({ url, filename, status: 'success' }));
+  ipcRenderer.on('download-completed', (_, { url, filename, path }) => {
+    store.dispatch(UIEffects.showDownloadNotification({ url, path, filename, status: 'success' }));
   });
 
-  ipcRenderer.on('download-error', (_, { url, filename }) => {
-    store.dispatch(UIEffects.showDownloadNotification({ url, filename, status: 'error' }));
+  ipcRenderer.on('download-error', (_, { url, filename, path }) => {
+    store.dispatch(UIEffects.showDownloadNotification({ url, path, filename, status: 'error' }));
   });
 
   // Fired on the first browser window when default browser is not Tofino.


### PR DESCRIPTION
… r=vporof"

I think the initial implementation didn't have this because of Notification limitations cuts off most text, atleast on OSX (and doesn't appear in the OSX notifications panel, which I don't really use anyway)

<img width="337" alt="screen shot 2016-10-10 at 12 53 50 pm" src="https://cloud.githubusercontent.com/assets/641267/19249790/176a98d2-8eec-11e6-8683-40ccdcf65cfc.png">
