### PR TITLE
Do not fire metadata parsing for non mainframes loading. r=vporof

### DIFF
--- a/app/ui/browser-modern/views/browser/page/index.jsx
+++ b/app/ui/browser-modern/views/browser/page/index.jsx
@@ -163,17 +163,23 @@ class Page extends Component {
       this.props.dispatch(UIEffects.setURLBarValue(pageId, validatedURL));
     });
 
-    this.webview.addEventListener('did-finish-load', () => {
+    this.webview.addEventListener('did-finish-load', e => {
       // Event fired when the navigation is done and onload event is dispatched.
       // May be emitted multiple times for every single frame.
       // Might not always be emitted after a `did-start-loading`.
+      if (!e.isMainFrame) {
+        return;
+      }
       this.props.dispatch(PageEffects.parsePageMetaData(this.props.pageId));
     });
 
-    this.webview.addEventListener('did-frame-finish-load', () => {
+    this.webview.addEventListener('did-frame-finish-load', e => {
       // Like `did-finish-load`, but fired only when an in-page load happens.
       // Parse the page metadata everytime something stops loading, to properly
       // handle in-page content changing and in-page navigations.
+      if (!e.isMainFrame) {
+        return;
+      }
       this.props.dispatch(PageEffects.parsePageMetaData(this.props.pageId));
     });
 


### PR DESCRIPTION
Go to a page with lots of iframes, and we fire handfuls of parse page metadata sagas which keep cancelling each other.

Here's some [Les Miserables chords to demonstrate](https://tabs.ultimate-guitar.com/t/the_miserables/a_heart_full_of_love_crd.htm) obscene amounts of frames