### PR TITLE
Write logs to disk in packaged builds

### DIFF
--- a/build/config/webpack.base.js
+++ b/build/config/webpack.base.js
@@ -31,7 +31,8 @@ export default {
     root,
     extensions: ['', '.js', '.jsx', '.json'],
     alias: {
-      'dtrace-provider': path.join(Const.BUILD_SYSTEM_DIR, 'config', 'empty_module.js'),
+      'dtrace-provider': path.join(Const.BUILD_SYSTEM_DIR, 'utils', 'empty_module.js'),
+      'app/shared/environment': path.join(Const.BUILD_SYSTEM_DIR, 'utils', 'empty_module.js'),
     },
   },
   plugins: [

--- a/build/config/webpack.main.js
+++ b/build/config/webpack.main.js
@@ -33,6 +33,11 @@ export default {
       LIBDIR: 'require("path").join(__dirname, "..")',
     }),
   ],
+  resolve: {
+    alias: {
+      'app/shared/environment': path.join(Const.SRC_DIR, 'shared', 'environment.js'),
+    },
+  },
   externals: [
     ...defaultConfig.externals,
     nodeExternals,

--- a/build/tasks.js
+++ b/build/tasks.js
@@ -122,7 +122,7 @@ const Tasks = {
     // XXX: All builds (including packaged) currently start their own
     // Content service. In the future, we should consider hosting
     // these somewhere else other than the user's own machine.
-    await this.build();
+    await this.build({ packaged: true });
     await Lazy.clean();
     await Lazy.package();
   },

--- a/build/utils/base-config.js
+++ b/build/utils/base-config.js
@@ -14,4 +14,8 @@ export default {
   // The `development` option indicates whether or not the build is
   // using unoptimized, unminified content and other things like that.
   development: false,
+
+  // The `packaged` flag indicates whether or not the build
+  // is a distributed, standalone exexcutable or not.
+  packaged: false,
 };

--- a/test/unit/lint/test-dependencies.js
+++ b/test/unit/lint/test-dependencies.js
@@ -69,6 +69,9 @@ describe('dependencies', () => {
       'electron',
       // Used for bunyan logging.
       'stream',
+      'path',
+      // Aliased via app/shared/environment
+      'app',
     ];
 
     const sources = await globMany(paths);
@@ -112,13 +115,18 @@ describe('dependencies', () => {
       'transit-js',
     ];
 
+    const ignored = [
+      // Aliased via webpack, a full path to a module i.e. `app/shared/environment`
+      'app',
+    ];
+
     const sources = await globMany(paths);
     const matches = await regexFiles(sources, REQUIRES_REGEX, IMPORTS_REGEX);
 
     // Stripping out the native node modules and adding the custom used packages
     // should leave only the main `package.json` plus the `app/package.json`
     // production dependencies.
-    const usedPackages = [...without(matches, ...native), ...unimported].sort();
+    const usedPackages = [...without(matches, ...native, ...ignored), ...unimported].sort();
     expect(usedPackages).toEqual(prodPackages);
 
     // Make sure no garbage is accumulated in the `unimported` array.


### PR DESCRIPTION
Fixed #1448.

Lots of wrestling with webpack here. Required for working on things that are packaged builds only, like #1418.

Ping @Mossop for review, and ping @victorporof for if there's a better way to handle the webpack build stuff to not include main process stuff in app/shared/logging.js in the renderer process. I don't want to bikeshed here, but this was a lot of work to get webpack to even build, silence linting and fixing dependency tests for this file loaded in all environments.

I can now see logs in real time in OSX's Console in ~/Library/Logs/Tofino/tofino.log -- curious if it's as good in Windows/Linux too