### PR TITLE
Also alias dtrace-provider in webpack.main.js to silence build warnin…

### DIFF
--- a/build/config/webpack.main.js
+++ b/build/config/webpack.main.js
@@ -35,6 +35,7 @@ export default {
   ],
   resolve: {
     alias: {
+      'dtrace-provider': path.join(Const.BUILD_SYSTEM_DIR, 'utils', 'empty_module.js'),
       'app/shared/environment': path.join(Const.SRC_DIR, 'shared', 'environment.js'),
     },
   },


### PR DESCRIPTION
…gs. Fixes #1455. r=vporof