### PR TITLE
Bump to UAS 0.0.5.

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -11,7 +11,7 @@
   "main": "main/index.js",
   "license": "Apache-2.0",
   "dependencies": {
-    "datomish-user-agent-service": "0.0.4",
+    "datomish-user-agent-service": "0.0.5",
     "fs-promise": "0.5.0",
     "thenify": "3.2.0",
     "yargs": "6.0.0"


### PR DESCRIPTION
This gets us SQLite 3.15, which comes with some lovely performance improvements, as well as some features we'll want to take advantage of in Datomish.

I've manually tested this in Tofino, and it passes both the UAS and Datomish's own test suites.

You can see the changes here:

https://github.com/mozilla/datomish-user-agent-service/commit/a2528361fd2efd94b1091469b1f79684cb929306
https://github.com/mozilla/datomish/commit/b20e769abf955a53a1f10efb6968d2c6a0f87fa4

@jsantell, r?