### PR TITLE
Refocus the find input when already open and pressing CmdOrCtrl+F, r=jsantell. Fixes #1396

### DIFF
--- a/app/ui/browser-modern/actions/page-actions.js
+++ b/app/ui/browser-modern/actions/page-actions.js
@@ -141,11 +141,17 @@ export function setPageUnpinned(pageId) {
 }
 
 export function showPageSearch(pageId) {
-  return setPageUIState(pageId, { searchVisible: true });
+  return dispatch => {
+    dispatch(setPageUIState(pageId, { searchVisible: true }));
+    dispatch(setPageUIState(pageId, { searchFocused: true }));
+  };
 }
 
 export function hidePageSearch(pageId) {
-  return setPageUIState(pageId, { searchVisible: false });
+  return dispatch => {
+    dispatch(setPageUIState(pageId, { searchVisible: false }));
+    dispatch(setPageUIState(pageId, { searchFocused: false }));
+  };
 }
 
 export function showCurrentPageSearch() {

--- a/app/ui/browser-modern/actions/page-effects.js
+++ b/app/ui/browser-modern/actions/page-effects.js
@@ -243,17 +243,18 @@ export function performCurrentPageDownload(url) {
   };
 }
 
-export function performPageSearch(pageId, text, doc = document) {
+export function performPageSearch(pageId, text, options, doc = document) {
   return {
     type: EffectTypes.PERFORM_PAGE_SEARCH,
     webview: getWebViewForPageId(doc, pageId),
     text,
+    options,
   };
 }
 
-export function performCurrentPageSearch(text) {
+export function performCurrentPageSearch(text, options) {
   return (dispatch, getState) => {
-    dispatch(performPageSearch(PagesSelectors.getSelectedPageId(getState()), text));
+    dispatch(performPageSearch(PagesSelectors.getSelectedPageId(getState()), text, options));
   };
 }
 

--- a/app/ui/browser-modern/model/page-ui-state.js
+++ b/app/ui/browser-modern/model/page-ui-state.js
@@ -20,6 +20,7 @@ const PageUIState = register(Immutable.Record({
   preventInteraction: false,
   zoomLevel: 0,
   searchVisible: false,
+  searchFocused: false,
   pinned: false,
 }, `PageUIState_v${VERSION}`));
 

--- a/app/ui/browser-modern/sagas/page-sagas.js
+++ b/app/ui/browser-modern/sagas/page-sagas.js
@@ -12,6 +12,7 @@ specific language governing permissions and limitations under the License.
 
 import { call, apply, select, put } from 'redux-saga/effects';
 
+import { logger } from '../../../shared/logging';
 import { ipcRenderer, remote } from '../../../shared/electron';
 import { takeLatestMultiple, takeEveryMultiple } from '../../shared/util/saga-util';
 import PageState from '../model/page-state';
@@ -165,11 +166,15 @@ export function* performPageDownload({ webview, url }) {
   yield apply(webview, webview.downloadURL, [url]);
 }
 
-export function* performPageSearch({ webview, text }) {
-  if (!text) {
-    yield apply(webview, webview.stopFindInPage, ['clearSelection']);
-  } else {
-    yield apply(webview, webview.findInPage, [text]);
+export function* performPageSearch({ webview, text, options }) {
+  try {
+    if (!text) {
+      yield apply(webview, webview.stopFindInPage, ['clearSelection']);
+    } else {
+      yield apply(webview, webview.findInPage, [text, options]);
+    }
+  } catch (e) {
+    logger.warn(e);
   }
 }
 

--- a/app/ui/browser-modern/selectors/pages.js
+++ b/app/ui/browser-modern/selectors/pages.js
@@ -114,6 +114,10 @@ export function getPageSearchVisible(state, id) {
   return getPageUIState(state, id).searchVisible;
 }
 
+export function getPageSearchFocused(state, id) {
+  return getPageUIState(state, id).searchFocused;
+}
+
 export function getPageZoomLevel(state, id) {
   return getPageUIState(state, id).zoomLevel;
 }


### PR DESCRIPTION
Signed-off-by: Victor Porof <vporof@mozilla.com>