### PR TITLE
Use same webpack config for content service as main for resolving app…

### DIFF
--- a/build/config/webpack.services.content.js
+++ b/build/config/webpack.services.content.js
@@ -30,6 +30,13 @@ export default {
       LIBDIR: 'require("path").join(__dirname, "..", "..")',
     }),
   ],
+  resolve: {
+    ...defaultConfig.resolve,
+    alias: {
+      ...defaultConfig.resolve.alias,
+      'app/shared/environment': path.join(Const.SRC_DIR, 'shared', 'environment.js'),
+    },
+  },
   externals: [
     ...defaultConfig.externals,
     nodeExternals,


### PR DESCRIPTION
…/shared/environment for the logger to fix content service crash.