### PR TITLE
Use different ports for packaged builds to prevent conflicts when dev…

### DIFF
--- a/app/shared/constants/endpoints.js
+++ b/app/shared/constants/endpoints.js
@@ -10,10 +10,12 @@
  specific language governing permissions and limitations under the License.
  */
 
+import BUILD_CONFIG from '../../build-config';
+
 export const TOFINO_PROTOCOL = 'tofino';
 
 export const UA_SERVICE_ADDR = 'localhost';
-export const UA_SERVICE_PORT = 9090;
+export const UA_SERVICE_PORT = BUILD_CONFIG.packaged ? 9091 : 9090;
 export const UA_SERVICE_VERSION = 'v1';
 
 export const UA_SERVICE_ORIGIN = `http://${UA_SERVICE_ADDR}:${UA_SERVICE_PORT}`;
@@ -21,7 +23,7 @@ export const UA_SERVICE_HTTP = `${UA_SERVICE_ORIGIN}/${UA_SERVICE_VERSION}`;
 export const UA_SERVICE_WS = `ws://${UA_SERVICE_ADDR}:${UA_SERVICE_PORT}/${UA_SERVICE_VERSION}/ws`;
 
 export const CONTENT_SERVER_ADDR = 'localhost';
-export const CONTENT_SERVER_PORT = 9191;
+export const CONTENT_SERVER_PORT = BUILD_CONFIG.packaged ? 9192 : 9191;
 export const CONTENT_SERVER_VERSION = 'v1';
 
 export const CONTENT_SERVER_ORIGIN = `http://${CONTENT_SERVER_ADDR}:${CONTENT_SERVER_PORT}`;


### PR DESCRIPTION
…eloping/running tests. r=vporof

Fixes #1418.

Easy once all the other prereqs are fixed, whew