### PR TITLE
Fix overflowing long URLs in history page. Fixes #1507. r=vporof

### DIFF
--- a/app/ui/content/views/history/history-item.jsx
+++ b/app/ui/content/views/history/history-item.jsx
@@ -35,6 +35,9 @@ const HISTORY_ANCHOR_STYLE = Style.registerStyle({
   padding: '6px 8px',
   textDecoration: 'none',
   color: 'rgba(0,0,0,0.9)',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
 });
 
 class HistoryItem extends Component {

--- a/app/ui/content/views/history/index.jsx
+++ b/app/ui/content/views/history/index.jsx
@@ -26,11 +26,11 @@ const HISTORY_STYLE = Style.registerStyle({
   flex: 1,
   flexDirection: 'column',
   padding: '20px 10%',
+  width: '80%',
 });
 
 const LIST_STYLE = Style.registerStyle({
   flex: 1,
-  overflow: 'auto',
 });
 
 const SEARCH_STYLE = Style.registerStyle({


### PR DESCRIPTION
Long URLs now work in any scenario they're used (AFAIK), like status bar, history page, autocomplete list.