### PR TITLE
Display a notification on pages that contain known issues

### DIFF
--- a/app/ui/browser-modern/css/theme.css
+++ b/app/ui/browser-modern/css/theme.css
@@ -71,4 +71,8 @@
   --theme-error-page-background-color: #FBFBFB;
   --theme-error-page-color: rgb(66, 78, 90);
   --theme-error-page-cert-background-color: #ddd;
+
+  /* Notification Bar */
+  --theme-notification-bar-border: 1px solid #bf8a01;
+  --theme-notification-bar-background: linear-gradient(#ffe13e, #ffc703);
 }

--- a/app/ui/browser-modern/util/notifications.js
+++ b/app/ui/browser-modern/util/notifications.js
@@ -1,0 +1,68 @@
+/*
+Copyright 2016 Mozilla
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License. You may obtain a copy of the
+License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/
+
+const NOTIFICATION_MESSAGES = {
+  codec: site => `Tofino may have issues playing media on ${site} due to licensing.`,
+  login: site => `Tofino may have issues with logging in on ${site}.`,
+  persona: () => 'Tofino has issues with logging in via Persona.',
+};
+
+const NOTIFICATIONS_BY_URL = {
+  feedly: {
+    message: NOTIFICATION_MESSAGES.login('Feedly'),
+    link: 'https://github.com/mozilla/tofino/issues/1129',
+  },
+  imgur: {
+    message: NOTIFICATION_MESSAGES.codec('imgur'),
+    link: 'https://github.com/mozilla/tofino/issues/1050',
+  },
+  // Blanket persona check on Mozilla domains
+  mozilla: {
+    message: NOTIFICATION_MESSAGES.persona(),
+    link: 'https://github.com/mozilla/tofino/issues/1027',
+  },
+  netflix: {
+    message: NOTIFICATION_MESSAGES.codec('Netflix'),
+    link: 'https://github.com/mozilla/tofino/issues/997',
+  },
+  twitter: {
+    message: NOTIFICATION_MESSAGES.codec('Twitter'),
+    link: 'https://github.com/mozilla/tofino/issues/1050',
+  },
+  youtube: {
+    message: NOTIFICATION_MESSAGES.codec('YouTube'),
+    link: 'https://github.com/mozilla/tofino/issues/1004',
+  },
+};
+
+const NOTIFICATIONS_BY_URL_KEYS = Object.keys(NOTIFICATIONS_BY_URL);
+
+/**
+ * Takes a URL and crudely parses the hostname for popular sites that have
+ * known issues. The crudeness is due to subdomains and locale TLDs.
+ */
+export function getNotificationByURL(url) {
+  let hostname;
+  try {
+    hostname = new URL(url).hostname;
+  } catch (e) {
+    return null;
+  }
+
+  for (const domain of NOTIFICATIONS_BY_URL_KEYS) {
+    if (hostname.includes(domain)) {
+      return NOTIFICATIONS_BY_URL[domain];
+    }
+  }
+
+  return null;
+}

--- a/app/ui/browser-modern/views/browser/chrome-area.jsx
+++ b/app/ui/browser-modern/views/browser/chrome-area.jsx
@@ -20,6 +20,7 @@ import StatusBar from './decorations/statusbar';
 import DeveloperBar from './decorations/developerbar';
 import TabBar from './tabbar';
 import SearchBar from './decorations/searchbar';
+import NotificationBar from './decorations/notificationbar';
 
 import * as SharedPropTypes from '../../model/shared-prop-types';
 import * as UIConstants from '../../constants/ui';
@@ -43,6 +44,7 @@ class ChromeArea extends Component {
         className={CHROME_AREA_STYLE}>
         <WindowControls />
         <TabBar />
+        <NotificationBar />
         <DeveloperBar />
         <StatusBar />
         {this.props.pageIds.map(pageId => (

--- a/app/ui/browser-modern/views/browser/decorations/notificationbar.jsx
+++ b/app/ui/browser-modern/views/browser/decorations/notificationbar.jsx
@@ -1,0 +1,91 @@
+/*
+Copyright 2016 Mozilla
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License. You may obtain a copy of the
+License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/
+
+import React, { Component, PropTypes } from 'react';
+import PureRenderMixin from 'react-addons-pure-render-mixin';
+import { connect } from 'react-redux';
+
+import Style from '../../../../shared/style';
+import { getNotificationByURL } from '../../../util/notifications';
+import * as PagesSelectors from '../../../selectors/pages';
+import * as PageEffects from '../../../actions/page-effects';
+
+const NOTIFICATION_BAR_STYLE = Style.registerStyle({
+  position: 'fixed',
+  bottom: 0,
+  left: 0,
+  right: 0,
+  height: '24px',
+  padding: '0 20px',
+  borderTop: 'var(--theme-notification-bar-border)',
+  borderBottom: 'var(--theme-notification-bar-border)',
+  color: 'rgba(0,0,0,0.95)',
+  background: 'var(--theme-notification-bar-background)',
+  width: '100%',
+  alignItems: 'center',
+});
+
+const NOTIFICATION_LINK_STYLE = Style.registerStyle({
+  marginLeft: '5px',
+  color: 'rgba(0,0,0,0.95)',
+  border: 'none',
+  background: 'none',
+  cursor: 'pointer',
+  padding: 0,
+});
+
+class NotificationBar extends Component {
+  constructor(props) {
+    super(props);
+    this.shouldComponentUpdate = PureRenderMixin.shouldComponentUpdate.bind(this);
+  }
+
+  onLinkClick = () => {
+    this.props.dispatch(PageEffects.createPageSession(this.props.link));
+  }
+
+  render() {
+    if (!this.props.message) {
+      return null;
+    }
+    return (
+      <div className={`browser-notificationbar ${NOTIFICATION_BAR_STYLE}`}>
+        <span>{this.props.message}</span>
+        <button className={NOTIFICATION_LINK_STYLE}
+          onClick={this.onLinkClick}
+          title={this.props.link}>
+          {'[More Info...]'}
+        </button>
+      </div>
+    );
+  }
+}
+
+NotificationBar.displayName = 'NotificationBar';
+
+NotificationBar.propTypes = {
+  link: PropTypes.string,
+  message: PropTypes.string,
+  dispatch: PropTypes.func.isRequired,
+};
+
+function mapStateToProps(state) {
+  const page = PagesSelectors.getSelectedPage(state) || {};
+  const { link, message } = getNotificationByURL(page.location) || {};
+
+  return {
+    link,
+    message,
+  };
+}
+
+export default connect(mapStateToProps)(NotificationBar);


### PR DESCRIPTION
This could be helpful if more people start using it and explain any frustrating bugs they run into and a link to the appropriate GH issue for more information, and possibly reduce dupe bugs.

Only based off of login and codec errors at the moment -- anything else we could add?

<img width="1057" alt="screen shot 2016-11-02 at 10 04 31 am" src="https://cloud.githubusercontent.com/assets/641267/19939501/8ea8e5dc-a0e6-11e6-88e6-28a593145f1a.png">
