### PR TITLE
When displaying tofino://historyrestore?url= URLs, display the url q…

### DIFF
--- a/app/ui/content/views/history/history-item.jsx
+++ b/app/ui/content/views/history/history-item.jsx
@@ -14,6 +14,7 @@ import React, { Component } from 'react';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 
 import Style from '../../../shared/style';
+import { prettyUrl, resolveHistoryRestoreUrl } from '../../../shared/util/url-util';
 
 import * as ContentPropTypes from '../../model/content-prop-types';
 import ListItem from '../../../shared/widgets/list-item';
@@ -47,16 +48,17 @@ class HistoryItem extends Component {
   }
 
   render() {
+    const { title, uri, snippet } = this.props.page;
     return (
       <ListItem className={HISTORY_ITEM_STYLE}>
         <a className={HISTORY_ANCHOR_STYLE}
-          href={this.props.page.uri}
-          title={this.props.page.title || this.props.page.uri}>
-          {this.props.page.title || this.props.page.uri}
+          href={resolveHistoryRestoreUrl(uri)}
+          title={title || prettyUrl(uri)}>
+          {title || prettyUrl(uri)}
         </a>
-        {this.props.page.snippet
+        {snippet
         ? (
-          <p>{this.props.page.snippet}</p>
+          <p>{snippet}</p>
         ) : (
           null
         )}

--- a/app/ui/shared/util/url-util.js
+++ b/app/ui/shared/util/url-util.js
@@ -26,6 +26,26 @@ export function createHistoryRestoreUrl(historyURLs, historyIndex) {
 }
 
 /**
+ * Takes a URL string and if it's a history restore URL
+ * with a url query param, return the parsed form of the URL.
+ * So if we have a history restore URL, like
+ * `tofino://historyrestore?url=http:\/\/mozilla.org`,
+ * just return `url` param to not display the internals of how
+ * restoration works.
+ *
+ * @param {String} url
+ * @return {String}
+ */
+export function resolveHistoryRestoreUrl(url = '') {
+  if (url.startsWith(HISTORY_RESTORE_ADDR)) {
+    // Pass in `true` as second parameter to indicate we want to parse
+    // the querystring as an object.
+    return parse(url, true).query.url || url;
+  }
+  return url;
+}
+
+/**
  * Takes a URL string and strips information to make it more
  * suitable for viewing, like stripping out common protocols
  * and subdomains.
@@ -33,7 +53,12 @@ export function createHistoryRestoreUrl(historyURLs, historyIndex) {
  * @param {String} url
  * @return {String}
  */
-export function prettyUrl(url) {
+export function prettyUrl(url = '') {
+  // Display the resolved URL if it's the history restore page.
+  if (url.startsWith(HISTORY_RESTORE_ADDR)) {
+    url = resolveHistoryRestoreUrl(url);
+  }
+
   const parsedUrl = parse(url);
 
   // Remove the protocol from being displayed if it's

--- a/test/unit/shared/test-url.js
+++ b/test/unit/shared/test-url.js
@@ -3,7 +3,13 @@
 
 import expect from 'expect';
 
-import { createHistoryRestoreUrl, prettyUrl } from '../../../app/ui/shared/util/url-util';
+import {
+  createHistoryRestoreUrl, prettyUrl, resolveHistoryRestoreUrl,
+} from '../../../app/ui/shared/util/url-util';
+
+const HISTORY_RESTORE_WITH_URL = 'tofino://historyrestore/?url=https%3A//www.mozilla.org/';
+const HISTORY_RESTORE_WITH_HISTORY = 'tofino://historyrestore/' +
+  '?history=%5B%22tofino%3A//history/%22%2C%22https%3A//www.mozilla.org/%22%5D&historyIndex=0';
 
 describe('prettyUrl', () => {
   it('Strips http, https protocols', () => {
@@ -15,6 +21,29 @@ describe('prettyUrl', () => {
   it('Strips only www subdomains', () => {
     expect(prettyUrl('http://www.mozilla.org/')).toBe('mozilla.org/');
     expect(prettyUrl('https://firefox.mozilla.org/')).toBe('firefox.mozilla.org/');
+  });
+
+  it('resolves historyrestore urls', () => {
+    expect(prettyUrl(HISTORY_RESTORE_WITH_URL)).toBe('mozilla.org/');
+  });
+
+  it('does not resolve historyrestore urls that contain multiple histories to be injected', () => {
+    expect(prettyUrl(HISTORY_RESTORE_WITH_HISTORY)).toBe(HISTORY_RESTORE_WITH_HISTORY);
+  });
+});
+
+describe('resolveHistoryRestoreUrl', () => {
+  it('does not resolve non-historyrestore urls', () => {
+    expect(resolveHistoryRestoreUrl('https://mozilla.org/')).toBe('https://mozilla.org/');
+  });
+
+  it('resolves historyrestore urls', () => {
+    expect(resolveHistoryRestoreUrl(HISTORY_RESTORE_WITH_URL)).toBe('https://www.mozilla.org/');
+  });
+
+  it('does not resolve historyrestore urls that contain multiple histories to be injected', () => {
+    expect(resolveHistoryRestoreUrl(HISTORY_RESTORE_WITH_HISTORY))
+      .toBe(HISTORY_RESTORE_WITH_HISTORY);
   });
 });
 


### PR DESCRIPTION
…uery param instead of the tofino history restore page. Fixes #1535. r=vporof