### PR TITLE
Restoring a session should use historyrestore URLs to preserve histor…

### DIFF
--- a/app/ui/browser-modern/actions/root-actions.js
+++ b/app/ui/browser-modern/actions/root-actions.js
@@ -19,9 +19,10 @@ export function setWindowId(windowId) {
   };
 }
 
-export function overwriteAppState(state) {
+export function overwriteAppState(state, options = {}) {
   return {
     type: ActionTypes.OVERWRITE_APP_STATE,
+    options,
     state,
   };
 }

--- a/app/ui/browser-modern/sagas/page-sagas.js
+++ b/app/ui/browser-modern/sagas/page-sagas.js
@@ -14,12 +14,12 @@ import assert from 'assert';
 import { call, apply, select, put } from 'redux-saga/effects';
 
 import { logger } from '../../../shared/logging';
-import { HISTORY_RESTORE_ADDR } from '../../../shared/constants/endpoints';
 import { ipcRenderer, remote } from '../../../shared/electron';
 import { infallible, takeLatestMultiple, takeEveryMultiple } from '../../shared/util/saga-util';
 import PageState from '../model/page-state';
 import PageContextMenu from '../views/menus/page-context-menu';
 import userAgentHttpClient from '../../../shared/user-agent-http-client';
+import { createHistoryRestoreUrl } from '../../shared/util/url-util';
 import * as Certificate from '../../shared/util/cert';
 import * as ContentScriptUtils from '../../shared/util/content-script-utils';
 import * as PageActions from '../actions/page-actions';
@@ -98,8 +98,7 @@ function* forkPageByOffset(pageId, offset) {
   const newHistoryIndex = historyIndex + offset;
   const currentPageIndex = yield select(PageSelectors.getPageIndexById, pageId);
   const historyURLs = yield select(PageSelectors.getPageHistoryURLs, pageId);
-  const historyList = escape(JSON.stringify(historyURLs));
-  const url = `${HISTORY_RESTORE_ADDR}/?history=${historyList}&historyIndex=${newHistoryIndex}`;
+  const url = createHistoryRestoreUrl(historyURLs, newHistoryIndex);
   const action = PageEffects.createPageSession({ location: url, selected: true });
   const { id } = action;
 

--- a/app/ui/browser-modern/sagas/session-sagas.js
+++ b/app/ui/browser-modern/sagas/session-sagas.js
@@ -113,7 +113,7 @@ export function* restoreBrowserWindowAppState({ serialized }) {
 
   // It's now safe to overwrite the app state and start watching it for changes,
   // since any other orchestrated initialization has been finished at this point.
-  yield put(RootActions.overwriteAppState(deserialized));
+  yield put(RootActions.overwriteAppState(deserialized, { restoreHistory: true }));
   yield put(SessionEffects.startSavingBrowserWindowAppState());
 }
 

--- a/app/ui/shared/util/url-util.js
+++ b/app/ui/shared/util/url-util.js
@@ -11,6 +11,7 @@ specific language governing permissions and limitations under the License.
 */
 
 import { parse, format } from 'url';
+import { HISTORY_RESTORE_ADDR } from '../../../shared/constants/endpoints';
 
 const PROTOCOLS_TO_HIDE = new Set([
   'http:',
@@ -18,6 +19,11 @@ const PROTOCOLS_TO_HIDE = new Set([
 ]);
 
 const WWW_SUBDOMAIN_REGEX = /^www\./;
+
+export function createHistoryRestoreUrl(historyURLs, historyIndex) {
+  const serializedHistory = escape(JSON.stringify(historyURLs));
+  return `${HISTORY_RESTORE_ADDR}/?history=${serializedHistory}&historyIndex=${historyIndex}`;
+}
 
 /**
  * Takes a URL string and strips information to make it more

--- a/test/unit/browser-modern/reducers/root-reducers-test.js
+++ b/test/unit/browser-modern/reducers/root-reducers-test.js
@@ -1,0 +1,83 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+import expect from 'expect';
+
+import reducer from '../../../../app/ui/browser-modern/reducers/root';
+import pagesReducer from '../../../../app/ui/browser-modern/reducers/pages';
+import * as pagesSelectors from '../../../../app/ui/browser-modern/selectors/pages';
+import * as ActionTypes from '../../../../app/ui/browser-modern/constants/action-types';
+import RootState from '../../../../app/ui/browser-modern/model/index';
+import Pages from '../../../../app/ui/browser-modern/model/pages';
+
+describe('root reducers', () => {
+  let state;
+
+  beforeEach(() => {
+    state = undefined;
+  });
+
+  it('should return the initial state', () => {
+    expect(reducer(undefined, {})).toEqual(undefined);
+  });
+
+  it('should handle OVERWRITE_APP_STATE', () => {
+    const statusText = 'OVERWRITE_APP_STATE test';
+    let newState = new RootState();
+    // Make a change so we can be sure it uses the passed in state, not an unmodified
+    // RootState.
+    newState = newState.setIn(['ui', 'statusText'], statusText);
+
+    const action = {
+      type: ActionTypes.OVERWRITE_APP_STATE,
+      state: newState,
+    };
+    expect(reducer(state, action)).toEqual(newState);
+  });
+
+  it('should handle OVERWRITE_APP_STATE with options.restoreHistory', () => {
+    const location = 'https://mozilla.org';
+    const history = [
+      'https://github.com',
+      'https://mozilla.org',
+      'https://eff.org',
+    ];
+
+    const preparations = [{
+      type: ActionTypes.CREATE_PAGE,
+      id: '1',
+      location,
+    }, {
+      type: ActionTypes.CREATE_PAGE,
+      id: '2',
+      location,
+    }, {
+      type: ActionTypes.SET_LOCAL_PAGE_HISTORY,
+      pageId: '1',
+      history,
+      historyIndex: 1,
+    }, {
+      type: ActionTypes.SET_LOCAL_PAGE_HISTORY,
+      pageId: '2',
+      history,
+      historyIndex: 2,
+    }];
+
+    const newState = (new RootState()).set('pages', preparations.reduce(pagesReducer, new Pages()));
+    const action = {
+      type: ActionTypes.OVERWRITE_APP_STATE,
+      state: newState,
+      options: {
+        restoreHistory: true,
+      },
+    };
+
+    state = reducer(state, action);
+    expect(pagesSelectors.getPageById(state, '1').location).toEqual(
+      `tofino://historyrestore/?history=${escape(JSON.stringify(history))}&historyIndex=1`
+    );
+    expect(pagesSelectors.getPageById(state, '2').location).toEqual(
+      `tofino://historyrestore/?history=${escape(JSON.stringify(history))}&historyIndex=2`
+    );
+  });
+});

--- a/test/unit/shared/test-url.js
+++ b/test/unit/shared/test-url.js
@@ -3,7 +3,7 @@
 
 import expect from 'expect';
 
-import { prettyUrl } from '../../../app/ui/shared/util/url-util';
+import { createHistoryRestoreUrl, prettyUrl } from '../../../app/ui/shared/util/url-util';
 
 describe('prettyUrl', () => {
   it('Strips http, https protocols', () => {
@@ -15,5 +15,18 @@ describe('prettyUrl', () => {
   it('Strips only www subdomains', () => {
     expect(prettyUrl('http://www.mozilla.org/')).toBe('mozilla.org/');
     expect(prettyUrl('https://firefox.mozilla.org/')).toBe('firefox.mozilla.org/');
+  });
+});
+
+describe('createHistoryRestoreUrl', () => {
+  it('Creates a serialized form of history with a history index', () => {
+    const history = [
+      'http://a.com',
+      'http://b.com',
+      'http://c.com',
+    ];
+    expect(createHistoryRestoreUrl(history, 1)).toBe(
+      `tofino://historyrestore/?history=${escape(JSON.stringify(history))}&historyIndex=1`
+    );
   });
 });


### PR DESCRIPTION
…y. Fixes #1426. r=vporof

Should land after #1540 due to having the urlbar have focus with the history restore URLs means those ugly URLs stay around after the real page loads.