### PR TITLE
Enable drag/drop for tabs. Fixes #1167

### DIFF
--- a/app/ui/browser-modern/views/browser/tabbar/tabs-list.jsx
+++ b/app/ui/browser-modern/views/browser/tabbar/tabs-list.jsx
@@ -13,6 +13,9 @@ specific language governing permissions and limitations under the License.
 import React, { Component } from 'react';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 import { connect } from 'react-redux';
+import HTML5Backend from 'react-dnd-html5-backend';
+import { DragDropContext } from 'react-dnd';
+
 
 import Style from '../../../../shared/style';
 import Tab from './tab';
@@ -59,4 +62,5 @@ function mapStateToProps(state) {
   };
 }
 
-export default connect(mapStateToProps)(TabsList);
+/* eslint-disable new-cap */
+export default connect(mapStateToProps)(DragDropContext(HTML5Backend)(TabsList));

--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
     "react": "15.3.2",
     "react-addons-perf": "15.3.2",
     "react-addons-pure-render-mixin": "15.3.2",
+    "react-dnd": "2.1.4",
+    "react-dnd-html5-backend": "2.1.2",
     "react-dom": "15.3.1",
     "react-free-style": "4.0.0",
     "react-immutable-proptypes": "2.1.0",


### PR DESCRIPTION
This adds tab reordering using https://github.com/gaearon/react-dnd - pretty easy.  I'm not sure the best way to test this without using end to end tests though, open to suggestions.