### PR TITLE
Bump dependencies.

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -11,7 +11,7 @@
   "main": "main/index.js",
   "license": "Apache-2.0",
   "dependencies": {
-    "datomish-user-agent-service": "0.0.5",
+    "datomish-user-agent-service": "0.0.7",
     "fs-promise": "0.5.0",
     "thenify": "3.2.0",
     "yargs": "6.0.0"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "reduce-reducers": "0.1.2",
     "redux": "3.6.0",
     "redux-immutable": "3.0.8",
-    "redux-logger": "2.7.2",
+    "redux-logger": "2.7.4",
     "redux-saga": "0.12.1",
     "source-map-support": "ncalexan/node-source-map-support#fileUrls-plus",
     "tmp": "0.0.29",


### PR DESCRIPTION
redux-logger was complaining that 2.7.2 is busted.

This has the new datomish-user-agent-service. That includes some dependency bumps and some Datomish improvements, including a new version of SQLite and the schema management vocabulary.

I tested this manually with my existing profile, which restored correctly, and I'll let CI complain about the rest!