### PR TITLE
Dedupe node_modules to shorten paths for Windows.  Fixes #1557

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,6 +27,9 @@ install:
   - npm prune
   - npm install --progress false --depth 0
   - npm install --progress false --depth 0
+  - cd app
+  - npm dedupe
+  - cd ..
 
 build: off
 


### PR DESCRIPTION
This appears to fix #1557 as per https://github.com/mozilla/tofino/issues/1557#issuecomment-262239739.